### PR TITLE
feat: lighten theme and add top header

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,17 @@
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
+  background: linear-gradient(180deg, #ffffff 0%, #e6f7ff 50%, #91d5ff 100%);
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 16px;
+  background: linear-gradient(90deg, #ffffff 0%, #e6f7ff 100%);
+}
+
+.app-sider {
+  background: linear-gradient(180deg, #ffffff 0%, #e6f7ff 50%, #91d5ff 100%);
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,6 +1,9 @@
-import { Layout, Menu } from 'antd';
+import { useEffect, useState } from 'react';
+import { Layout, Menu, Button, Space } from 'antd';
+import { BellOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
 import { Link, useLocation } from 'react-router-dom';
 import type { MenuProps } from 'antd';
+import { supabase } from '../supabaseClient';
 
 const { Sider, Content, Header } = Layout;
 
@@ -35,19 +38,57 @@ const items: MenuProps['items'] = [
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUserEmail(data.user?.email ?? null);
+    });
+  }, []);
+
+  const routeTitles: Record<string, string> = {
+    '/': 'Dashboard',
+    '/documents/estimate': 'Шахматка',
+    '/documents/estimate-monolith': 'Шахматка монолит',
+    '/documents/work-volume': 'ВОР для подрядчиков',
+    '/documents/cost': 'Смета',
+    '/library/docs': 'Документация',
+    '/library/rd-codes': 'Шифры РД',
+    '/library/pd-codes': 'Шифры ПД',
+    '/references': 'Справочники',
+    '/reports': 'Отчёты',
+    '/admin': 'Администрирование',
+  };
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+  };
+
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>Blueprintflow</div>
+      <Sider collapsible className="app-sider">
+        <div style={{ color: '#003a8c', padding: 16, fontWeight: 600 }}>Blueprintflow</div>
         <Menu
-          theme="dark"
+          theme="light"
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}
         />
       </Sider>
       <Layout>
-        <Header style={{ background: '#fff', padding: 0 }} />
+        <Header className="app-header">
+          <div>{routeTitles[location.pathname] || ''}</div>
+          <Space size="middle">
+            <BellOutlined />
+            <Space>
+              <UserOutlined />
+              <span>{userEmail ?? 'Гость'}</span>
+            </Space>
+            <Button type="text" icon={<LogoutOutlined />} onClick={handleLogout}>
+              Выход
+            </Button>
+          </Space>
+        </Header>
         <Content style={{ margin: '16px' }}>{children}</Content>
       </Layout>
     </Layout>


### PR DESCRIPTION
## Summary
- lighten global color palette with white-to-blue gradients
- add full-width header showing section title, notifications, user info, and logout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689322fd2364832e9527d3ccf736a904