### PR TITLE
Добавлены элементы на странице справочников

### DIFF
--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -1,23 +1,37 @@
 import { useState } from 'react';
-import { Select } from 'antd';
+import { Button, Select } from 'antd';
 import DataTable from '../components/DataTable';
 
 const options = [
   { value: 'works', label: 'Работы' },
   { value: 'materials', label: 'Материалы' },
   { value: 'authors', label: 'Авторы' },
+  { value: 'cost_categories', label: 'Категории затрат' },
 ];
 
 export default function References() {
   const [table, setTable] = useState(options[0].value);
   return (
     <>
-      <Select
-        options={options}
-        value={table}
-        onChange={setTable}
-        style={{ width: 240, marginBottom: 16 }}
-      />
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span>Название справочника:</span>
+          <Select options={options} value={table} onChange={setTable} style={{ width: 240 }} />
+        </div>
+        <div>
+          <Button type="primary" style={{ marginRight: 8 }}>
+            Добавить
+          </Button>
+          <Button>Вывести</Button>
+        </div>
+      </div>
       <DataTable table={table} />
     </>
   );


### PR DESCRIPTION
## Summary
- добавить подпись и кнопки управления в разделе выбора справочника
- добавить справочник "Категории затрат"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68932dac5a88832e8d14b7d79e40ca53