### PR TITLE
feat: добавить ввод категорий затрат

### DIFF
--- a/src/components/CostCategoriesForm.tsx
+++ b/src/components/CostCategoriesForm.tsx
@@ -1,0 +1,92 @@
+import { Table, Input, Button } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+
+export interface CostCategoryRow {
+  key: string;
+  category_id?: string;
+  parent_id?: string;
+  name?: string;
+  level?: string;
+  created_at?: string;
+  author?: string;
+}
+
+interface CostCategoriesFormProps {
+  rows: CostCategoryRow[];
+  setRows: (rows: CostCategoryRow[]) => void;
+}
+
+export default function CostCategoriesForm({ rows, setRows }: CostCategoriesFormProps) {
+  const updateRow = (index: number, field: keyof CostCategoryRow, value: string) => {
+    const newRows = [...rows];
+    newRows[index] = { ...newRows[index], [field]: value };
+    setRows(newRows);
+  };
+
+  const addRowAfter = (index: number) => {
+    const newRow: CostCategoryRow = { key: `${Date.now()}-${Math.random()}` };
+    const newRows = [...rows.slice(0, index + 1), newRow, ...rows.slice(index + 1)];
+    setRows(newRows);
+  };
+
+  const columns = [
+    {
+      title: 'ID',
+      dataIndex: 'category_id',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Input
+          value={rows[index].category_id}
+          onChange={(e) => updateRow(index, 'category_id', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'ID родителя',
+      dataIndex: 'parent_id',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Input
+          value={rows[index].parent_id}
+          onChange={(e) => updateRow(index, 'parent_id', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'Название',
+      dataIndex: 'name',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Input value={rows[index].name} onChange={(e) => updateRow(index, 'name', e.target.value)} />
+      ),
+    },
+    {
+      title: 'Уровень',
+      dataIndex: 'level',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Input value={rows[index].level} onChange={(e) => updateRow(index, 'level', e.target.value)} />
+      ),
+    },
+    {
+      title: 'Создано',
+      dataIndex: 'created_at',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Input
+          value={rows[index].created_at}
+          onChange={(e) => updateRow(index, 'created_at', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'Автор',
+      dataIndex: 'author',
+      render: (_: unknown, __: CostCategoryRow, index: number) => rows[index].author,
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      render: (_: unknown, __: CostCategoryRow, index: number) => (
+        <Button icon={<PlusOutlined />} onClick={() => addRowAfter(index)} />
+      ),
+    },
+  ];
+
+  return <Table dataSource={rows} columns={columns} pagination={false} rowKey="key" />;
+}

--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Select } from 'antd';
 import DataTable from '../components/DataTable';
+import CostCategoriesForm, {
+  CostCategoryRow,
+} from '../components/CostCategoriesForm';
+import { supabase } from '../supabaseClient';
 
 const options = [
   { value: 'works', label: 'Работы' },
@@ -11,6 +15,47 @@ const options = [
 
 export default function References() {
   const [table, setTable] = useState(options[0].value);
+  const [adding, setAdding] = useState(false);
+  const [rows, setRows] = useState<CostCategoryRow[]>([]);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [currentUser, setCurrentUser] = useState('');
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data.user) setCurrentUser(data.user.id);
+    });
+  }, []);
+
+  const handleAdd = () => {
+    if (table !== 'cost_categories') return;
+    const newRows: CostCategoryRow[] = Array.from({ length: 10 }, (_, i) => ({
+      key: `${Date.now()}-${i}`,
+      created_at: new Date().toISOString(),
+      author: currentUser,
+    }));
+    setRows(newRows);
+    setAdding(true);
+  };
+
+  const handleSave = async () => {
+    const payload = rows
+      .filter((r) => r.category_id && r.name && r.level)
+      .map((r) => ({
+        category_id: Number(r.category_id),
+        parent_id: r.parent_id ? Number(r.parent_id) : null,
+        name: r.name!,
+        level: r.level!,
+        created_at: r.created_at || new Date().toISOString(),
+        author: r.author || currentUser,
+      }));
+    if (payload.length) {
+      await supabase.from('cost_categories').insert(payload);
+      setRefreshKey((k) => k + 1);
+    }
+    setAdding(false);
+    setRows([]);
+  };
+
   return (
     <>
       <div
@@ -23,16 +68,34 @@ export default function References() {
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span>Название справочника:</span>
-          <Select options={options} value={table} onChange={setTable} style={{ width: 240 }} />
+          <Select
+            options={options}
+            value={table}
+            onChange={(value) => {
+              setTable(value);
+              setAdding(false);
+            }}
+            style={{ width: 240 }}
+          />
         </div>
         <div>
-          <Button type="primary" style={{ marginRight: 8 }}>
-            Добавить
-          </Button>
+          {table === 'cost_categories' && adding ? (
+            <Button type="primary" style={{ marginRight: 8 }} onClick={handleSave}>
+              Сохранить
+            </Button>
+          ) : (
+            <Button type="primary" style={{ marginRight: 8 }} onClick={handleAdd}>
+              Добавить
+            </Button>
+          )}
           <Button>Вывести</Button>
         </div>
       </div>
-      <DataTable table={table} />
+      {table === 'cost_categories' && adding ? (
+        <CostCategoriesForm rows={rows} setRows={setRows} />
+      ) : (
+        <DataTable key={refreshKey} table={table} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- добавить форму ввода для справочника "Категории затрат"
- реализовать сохранение новых записей в Supabase

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68933495dea4832ea5f448d962e45c4c