### PR TITLE
feat: add departments admin page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import References from './pages/References';
 import Reports from './pages/Reports';
 import Admin from './pages/Admin';
 import Users from './pages/Users';
+import Departments from './pages/Departments';
 
 export default function App() {
   return (
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/reports" element={<Reports />} />
         <Route path="/admin" element={<Admin />} />
         <Route path="/admin/users" element={<Users />} />
+        <Route path="/admin/departments" element={<Departments />} />
       </Routes>
     </MainLayout>
   );

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -59,6 +59,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
     '/reports': 'Отчёты',
     '/admin': 'Администрирование',
     '/admin/users': 'Пользователи',
+    '/admin/departments': 'Подразделения',
   };
 
   const handleLogout = async () => {

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -10,7 +10,9 @@ export default function Admin() {
             <Button>Пользователи</Button>
           </Link>
           <Button>Роли</Button>
-          <Button>Подразделения</Button>
+          <Link to="/admin/departments">
+            <Button>Подразделения</Button>
+          </Link>
           <Button>Привилегии</Button>
           <Button>Настройки</Button>
         </Space>

--- a/src/pages/Departments.tsx
+++ b/src/pages/Departments.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { Button, Space, Table, Input, message } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { Link } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+
+interface RowData {
+  key: number;
+  department: string;
+  description: string;
+}
+
+export default function Departments() {
+  const [rows, setRows] = useState<RowData[]>([]);
+
+  const handleAdd = () => {
+    setRows([{ key: Date.now(), department: '', description: '' }]);
+  };
+
+  const addRowAfter = (index: number) => {
+    const newRow: RowData = { key: Date.now() + index, department: '', description: '' };
+    setRows((prev) => {
+      const copy = [...prev];
+      copy.splice(index + 1, 0, newRow);
+      return copy;
+    });
+  };
+
+  const handleChange = (index: number, field: keyof Omit<RowData, 'key'>, value: string) => {
+    setRows((prev) => {
+      const copy = [...prev];
+      copy[index] = { ...copy[index], [field]: value };
+      return copy;
+    });
+  };
+
+  const handleSave = async () => {
+    const { data: last, error: fetchError } = await supabase
+      .from('departments')
+      .select('department_id')
+      .order('department_id', { ascending: false })
+      .limit(1);
+
+    if (fetchError) {
+      message.error('Ошибка сохранения');
+      return;
+    }
+
+    const startId = last?.[0]?.department_id ? last[0].department_id + 1 : 1;
+
+    const payload = rows.map((r, idx) => ({
+      department_id: startId + idx,
+      department: r.department,
+      description: r.description,
+      user_id: 1,
+    }));
+    const { error } = await supabase.from('departments').insert(payload);
+    if (error) {
+      message.error('Ошибка сохранения');
+      return;
+    }
+    message.success('Сохранено');
+    setRows([]);
+  };
+
+  const columns: ColumnsType<RowData> = [
+    {
+      title: 'Название',
+      dataIndex: 'department',
+      render: (_value, _record, index) => (
+        <Input
+          value={rows[index].department}
+          onChange={(e) => handleChange(index, 'department', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'Описание',
+      dataIndex: 'description',
+      render: (_value, _record, index) => (
+        <Input
+          value={rows[index].description}
+          onChange={(e) => handleChange(index, 'description', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      render: (_value, _record, index) => <Button onClick={() => addRowAfter(index)}>+</Button>,
+    },
+  ];
+
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <Space>
+          <Link to="/admin/users">
+            <Button>Пользователи</Button>
+          </Link>
+          <Button>Роли</Button>
+          <Link to="/admin/departments">
+            <Button type="primary">Подразделения</Button>
+          </Link>
+          <Button>Привилегии</Button>
+          <Button>Настройки</Button>
+        </Space>
+        <Space>
+          {rows.length === 0 ? (
+            <Button type="primary" onClick={handleAdd}>
+              Добавить
+            </Button>
+          ) : (
+            <Button type="primary" onClick={handleSave}>
+              Сохранить
+            </Button>
+          )}
+          <Button>Редактировать</Button>
+        </Space>
+      </div>
+      {rows.length > 0 && (
+        <Table<RowData>
+          dataSource={rows}
+          columns={columns}
+          pagination={false}
+          rowKey="key"
+        />
+      )}
+    </>
+  );
+}
+

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -10,7 +10,9 @@ export default function Users() {
             <Button type="primary">Пользователи</Button>
           </Link>
           <Button>Роли</Button>
-          <Button>Подразделения</Button>
+          <Link to="/admin/departments">
+            <Button>Подразделения</Button>
+          </Link>
           <Button>Привилегии</Button>
           <Button>Настройки</Button>
         </Space>


### PR DESCRIPTION
## Summary
- add departments admin page with editable rows
- wire up admin navigation and routes
- generate unique department_id before saving

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68934e1174a8832eb18b2d735a28ba04