### PR TITLE
feat: add theme and chessboard table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,8 @@ const App = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="light" style={{ background: '#fafafa' }} collapsible>
+      <Sider theme="light" style={{ background: '#e6f7ff' }} collapsible>
+        <div style={{ color: '#000', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu theme="light" mode="inline" items={items} />
       </Sider>
       <Layout>

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -6,21 +6,12 @@ import { supabase } from '../lib/supabase';
 
 const { Header } = Layout;
 
-const pageTitles: Record<string, string> = {
-  '/': 'Dashboard',
-  '/documents': 'Документы',
-  '/documents/chessboard': 'Шахматка',
-  '/documents/vor': 'ВОР',
-  '/documents/estimate': 'Шахматка',
-  '/documents/estimate-monolith': 'Шахматка монолит',
-  '/documents/work-volume': 'ВОР для подрядчиков',
-  '/documents/cost': 'Смета',
-  '/library/docs': 'Документация',
-  '/library/rd-codes': 'Шифры РД',
-  '/library/pd-codes': 'Шифры ПД',
-  '/references': 'Справочники',
-  '/reports': 'Отчёты',
-  '/admin': 'Администрирование',
+const breadcrumbs: Record<string, string[]> = {
+  '/': ['Dashboard'],
+  '/documents': ['Документы'],
+  '/documents/chessboard': ['Документы', 'Шахматка'],
+  '/documents/vor': ['Документы', 'ВОР'],
+  '/references': ['Справочники'],
 };
 
 export default function PortalHeader() {
@@ -37,14 +28,14 @@ export default function PortalHeader() {
   return (
     <Header
       style={{
-        background: '#f5f5f5',
+        background: '#e6f7ff',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
       }}
     >
-      <span>{pageTitles[pathname] || ''}</span>
+      <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>
       <Space size="middle">
         <Button type="text" icon={<BellOutlined />} />
         <Space>

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -38,8 +38,8 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const location = useLocation();
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="light" style={{ background: '#fafafa' }} collapsible>
-        <div style={{ color: '#000', padding: 16, fontWeight: 600 }}>Blueprintflow</div>
+      <Sider theme="light" style={{ background: '#e6f7ff' }} collapsible>
+        <div style={{ color: '#000', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
           theme="light"
           mode="inline"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ConfigProvider } from 'antd'
 import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
@@ -10,10 +11,20 @@ const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#1677ff',
+          colorBgLayout: '#e6f7ff',
+          colorBgContainer: '#ffffff',
+        },
+      }}
+    >
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ConfigProvider>
   </StrictMode>,
 )

--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -1,11 +1,5 @@
 import { Outlet } from 'react-router-dom'
-import { Typography } from 'antd'
 
-const Documents = () => (
-  <div>
-    <Typography.Title level={2}>Документы</Typography.Title>
-    <Outlet />
-  </div>
-)
+const Documents = () => <Outlet />
 
 export default Documents

--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -1,7 +1,3 @@
-import { Typography } from 'antd'
-
-const References = () => (
-  <Typography.Title level={2}>Справочники</Typography.Title>
-)
+const References = () => <div />
 
 export default References

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,7 +1,134 @@
-import { Typography } from 'antd'
+import { useState } from 'react'
+import { Button, Input, Space, Table } from 'antd'
+import { PlusOutlined } from '@ant-design/icons'
+import { supabase } from '../../lib/supabase'
 
-const Chessboard = () => (
-  <Typography.Title level={3}>Шахматка</Typography.Title>
-)
+interface RowData {
+  key: string
+  project: string
+  material: string
+  quantityPd: string
+  quantitySpec: string
+  quantityRd: string
+  unit: string
+}
 
-export default Chessboard
+const emptyRow = (): RowData => ({
+  key: Math.random().toString(36).slice(2),
+  project: '',
+  material: '',
+  quantityPd: '',
+  quantitySpec: '',
+  quantityRd: '',
+  unit: '',
+})
+
+export default function Chessboard() {
+  const [rows, setRows] = useState<RowData[]>([])
+  const [viewData, setViewData] = useState<RowData[]>([])
+  const [editing, setEditing] = useState(false)
+
+  const addRow = () => setRows([...rows, emptyRow()])
+
+  const handleChange = (key: string, field: keyof RowData, value: string) => {
+    setRows((prev) => prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)))
+  }
+
+  const handleAdd = () => {
+    setEditing(true)
+    if (rows.length === 0) addRow()
+  }
+
+  const handleSave = async () => {
+    if (!supabase) return
+    const payload = rows.map(({ key, ...rest }) => {
+      void key
+      return rest
+    })
+    await supabase.from('chessboard').insert(payload)
+    setEditing(false)
+  }
+
+  const handleShow = async () => {
+    if (!supabase) return
+    const { data } = await supabase.from('chessboard').select('*')
+    setViewData((data as RowData[]) ?? [])
+  }
+
+  const columns = [
+    {
+      title: 'проект',
+      dataIndex: 'project',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.project} onChange={(e) => handleChange(record.key, 'project', e.target.value)} />
+      ),
+    },
+    {
+      title: 'материал',
+      dataIndex: 'material',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.material} onChange={(e) => handleChange(record.key, 'material', e.target.value)} />
+      ),
+    },
+    {
+      title: 'количество материала по проектной документации',
+      dataIndex: 'quantityPd',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.quantityPd} onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)} />
+      ),
+    },
+    {
+      title: 'количество материала по спецификации',
+      dataIndex: 'quantitySpec',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.quantitySpec} onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)} />
+      ),
+    },
+    {
+      title: 'количество материала по рабочей документации',
+      dataIndex: 'quantityRd',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.quantityRd} onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)} />
+      ),
+    },
+    {
+      title: 'единица измерения',
+      dataIndex: 'unit',
+      render: (_: unknown, record: RowData) => (
+        <Input value={record.unit} onChange={(e) => handleChange(record.key, 'unit', e.target.value)} />
+      ),
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      render: (_: unknown, __: RowData, index: number) =>
+        index === rows.length - 1 ? (
+          <Button type="text" icon={<PlusOutlined />} onClick={addRow} />
+        ) : null,
+    },
+  ]
+
+  const viewColumns = [
+    { title: 'проект', dataIndex: 'project' },
+    { title: 'материал', dataIndex: 'material' },
+    { title: 'количество материала по проектной документации', dataIndex: 'quantityPd' },
+    { title: 'количество материала по спецификации', dataIndex: 'quantitySpec' },
+    { title: 'количество материала по рабочей документации', dataIndex: 'quantityRd' },
+    { title: 'единица измерения', dataIndex: 'unit' },
+  ]
+
+  return (
+    <div>
+      <Space style={{ marginBottom: 16 }}>
+        <Button onClick={editing ? handleSave : handleAdd}>{editing ? 'Сохранить' : 'Добавить'}</Button>
+        <Button onClick={handleShow}>Показать</Button>
+      </Space>
+      {editing && (
+        <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
+      )}
+      {!editing && viewData.length > 0 && (
+        <Table<RowData> dataSource={viewData} columns={viewColumns} pagination={false} rowKey="id" />
+      )}
+    </div>
+  )
+}

--- a/src/pages/documents/Vor.tsx
+++ b/src/pages/documents/Vor.tsx
@@ -1,7 +1,3 @@
-import { Typography } from 'antd'
-
-const Vor = () => (
-  <Typography.Title level={3}>ВОР</Typography.Title>
-)
+const Vor = () => <div />
 
 export default Vor


### PR DESCRIPTION
## Summary
- apply blue-light-blue-white theme via Ant Design tokens
- show portal name and breadcrumb path
- add editable table with save for chessboard page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894672d980c832ebad3fa97284cb58e