### PR TITLE
fix: store chessboard rows with status modal

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, Input, Space, Table, message } from 'antd'
+import { Button, Input, Modal, Space, Table, message } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import { supabase } from '../../lib/supabase'
 
@@ -41,7 +41,14 @@ export default function Chessboard() {
   }
 
   const handleSave = async () => {
-    if (!supabase) return
+    const tableName = 'chessboard'
+    if (!supabase) {
+      Modal.info({
+        title: 'Сохранение данных',
+        content: `Клиент базы данных не настроен. Таблица: ${tableName}`,
+      })
+      return
+    }
     const payload = rows.map(({ key, quantityPd, quantitySpec, quantityRd, ...rest }) => {
       void key
       return {
@@ -51,13 +58,17 @@ export default function Chessboard() {
         quantityRd: quantityRd ? Number(quantityRd) : null,
       }
     })
-    const { error } = await supabase.from('chessboard').insert(payload)
-    if (error) {
-      messageApi.error('Не удалось сохранить данные')
-      return
+    const { data, error } = await supabase.from(tableName).insert(payload).select()
+    Modal.info({
+      title: 'Сохранение данных',
+      content: error
+        ? `Не удалось сохранить данные в таблицу ${tableName}: ${error.message}`
+        : `Данные успешно сохранены в таблицу ${tableName}`,
+    })
+    if (!error) {
+      setViewData((data as RowData[]) ?? [])
+      setEditing(false)
     }
-    messageApi.success('Данные сохранены')
-    setEditing(false)
   }
 
   const handleShow = async () => {


### PR DESCRIPTION
## Summary
- show modal with table name and save status for chessboard entries
- load saved rows into view and exit edit mode on success

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689499f838f0832ebee3a9b135d295bc