### PR TITLE
fix: configure supabase client for chessboard page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 ## Разработка
 ```bash
 npm install
+cp .env.example .env # заполните значениями Supabase
 npm run dev
 ```
 
 ## Supabase
-Схема базы данных находится в файле `supabase.sql`. Для дополнительных требований см. `tech_task.md`.
+Схема базы данных находится в файле `supabase.sql`. Для подключения создайте файл `.env` с переменными `VITE_SUPABASE_URL` и `VITE_SUPABASE_ANON_KEY` (см. `.env.example`). Для дополнительных требований см. `tech_task.md`.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,5 +3,8 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const supabase: SupabaseClient | undefined =
-  url && key ? createClient(url, key) : undefined
+if (!url || !key) {
+  throw new Error('Supabase URL or anon key is missing')
+}
+
+export const supabase: SupabaseClient = createClient(url, key)

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -42,13 +42,6 @@ export default function Chessboard() {
 
   const handleSave = async () => {
     const tableName = 'chessboard'
-    if (!supabase) {
-      modal.info({
-        title: 'Сохранение данных',
-        content: `Клиент базы данных не настроен. Таблица: ${tableName}`,
-      })
-      return
-    }
     const payload = rows.map(({ key, quantityPd, quantitySpec, quantityRd, ...rest }) => {
       void key
       return {
@@ -72,7 +65,6 @@ export default function Chessboard() {
   }
 
   const handleShow = async () => {
-    if (!supabase) return
     const { data, error } = await supabase.from('chessboard').select('*')
     if (error) {
       message.error('Не удалось загрузить данные')


### PR DESCRIPTION
## Summary
- enforce Supabase configuration and remove undefined client handling
- document Supabase env requirements
- add environment example template

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a3b93590832e9978c91ac2495580