### PR TITLE
fix: handle missing Supabase credentials gracefully

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,7 +4,7 @@ const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!url || !key) {
-  throw new Error('Supabase URL or anon key is missing')
+  console.warn('Supabase URL or anon key is missing')
 }
 
-export const supabase: SupabaseClient = createClient(url, key)
+export const supabase: SupabaseClient | null = url && key ? createClient(url, key) : null

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -41,6 +41,10 @@ export default function Chessboard() {
   }
 
   const handleSave = async () => {
+    if (!supabase) {
+      message.error('Supabase не настроен')
+      return
+    }
     const tableName = 'chessboard'
     const payload = rows.map(({ key, quantityPd, quantitySpec, quantityRd, ...rest }) => {
       void key
@@ -65,6 +69,10 @@ export default function Chessboard() {
   }
 
   const handleShow = async () => {
+    if (!supabase) {
+      message.error('Supabase не настроен')
+      return
+    }
     const { data, error } = await supabase.from('chessboard').select('*')
     if (error) {
       message.error('Не удалось загрузить данные')


### PR DESCRIPTION
## Summary
- warn if Supabase URL or key missing and export nullable client
- guard Chessboard interactions when Supabase isn't configured

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894aad89ed8832ebd4c5bee1f2a6441