### PR TITLE
fix: use publishable Supabase key

### DIFF
--- a/portal_design.md
+++ b/portal_design.md
@@ -68,9 +68,13 @@ Dashboard
 ```ts
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY, {
-  auth: { persistSession: true }
-})
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY,
+  {
+    auth: { persistSession: true }
+  }
+)
 ```
 - Realtime: канал `Blueprintflow:{id}` для совместного редактирования с optimistic locking по `updated_at`.
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const url = import.meta.env.VITE_SUPABASE_URL
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY
+const publishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY
 
 export const supabase: SupabaseClient | undefined =
-  url && key ? createClient(url, key) : undefined
+  url && publishableKey ? createClient(url, publishableKey) : undefined


### PR DESCRIPTION
## Summary
- read Supabase publishable key from `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
- update docs to reference new env variable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895beae58e0832e8a6556ac96299c59