### PR TITLE
feat: add chessboard add/show modes

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { App, Button, Input, Space, Table } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import { supabase } from '../../lib/supabase'
@@ -35,6 +35,7 @@ const emptyRow = (): RowData => ({
 
 export default function Chessboard() {
   const [rows, setRows] = useState<RowData[]>([])
+  const [mode, setMode] = useState<'none' | 'add' | 'show'>('none')
   const { message } = App.useApp()
 
   const addRow = () => setRows([...rows, emptyRow()])
@@ -43,47 +44,50 @@ export default function Chessboard() {
     setRows((prev) => prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)))
   }
 
-  useEffect(() => {
-    const loadData = async () => {
-      if (!supabase) {
-        setRows([emptyRow()])
-        return
-      }
-      const { data, error } = await supabase.from('chessboard').select('*').limit(10)
-      if (error) {
-        console.error('Error fetching chessboard data:', error)
-        message.error('Не удалось загрузить данные')
-        setRows([emptyRow()])
-        return
-      }
-      if (!data || data.length === 0) {
-        setRows([emptyRow()])
-        return
-      }
-      setRows(
-        (data as DbRow[]).map((item) => ({
-          key: item.id ? String(item.id) : Math.random().toString(36).slice(2),
-          project: item.project ?? '',
-          material: item.material ?? '',
-          quantityPd:
-            item.quantityPd !== null && item.quantityPd !== undefined
-              ? String(item.quantityPd)
-              : '',
-          quantitySpec:
-            item.quantitySpec !== null && item.quantitySpec !== undefined
-              ? String(item.quantitySpec)
-              : '',
-          quantityRd:
-            item.quantityRd !== null && item.quantityRd !== undefined
-              ? String(item.quantityRd)
-              : '',
-          unit: item.unit ?? '',
-        }))
-      )
-    }
+  const handleAdd = () => {
+    setRows([emptyRow()])
+    setMode('add')
+  }
 
-    void loadData()
-  }, [message])
+  const handleShow = async () => {
+    setMode('show')
+    if (!supabase) {
+      setRows([emptyRow()])
+      return
+    }
+    const { data, error } = await supabase.from('chessboard').select('*').limit(1)
+    if (error) {
+      console.error('Error fetching chessboard data:', error)
+      message.error('Не удалось загрузить данные')
+      setRows([emptyRow()])
+      return
+    }
+    if (!data || data.length === 0) {
+      setRows([emptyRow()])
+      return
+    }
+    const item = data[0] as DbRow
+    setRows([
+      {
+        key: item.id ? String(item.id) : Math.random().toString(36).slice(2),
+        project: item.project ?? '',
+        material: item.material ?? '',
+        quantityPd:
+          item.quantityPd !== null && item.quantityPd !== undefined
+            ? String(item.quantityPd)
+            : '',
+        quantitySpec:
+          item.quantitySpec !== null && item.quantitySpec !== undefined
+            ? String(item.quantitySpec)
+            : '',
+        quantityRd:
+          item.quantityRd !== null && item.quantityRd !== undefined
+            ? String(item.quantityRd)
+            : '',
+        unit: item.unit ?? '',
+      },
+    ])
+  }
 
   const handleSave = async () => {
     const tableName = 'chessboard'
@@ -109,7 +113,7 @@ export default function Chessboard() {
     }
   }
 
-  const columns = [
+  const columnsAdd = [
     {
       title: 'проект',
       dataIndex: 'project',
@@ -162,12 +166,34 @@ export default function Chessboard() {
     },
   ]
 
+  const columnsShow = [
+    { title: 'проект', dataIndex: 'project' },
+    { title: 'материал', dataIndex: 'material' },
+    { title: 'количество материала по проектной документации', dataIndex: 'quantityPd' },
+    { title: 'количество материала по спецификации', dataIndex: 'quantitySpec' },
+    { title: 'количество материала по рабочей документации', dataIndex: 'quantityRd' },
+    { title: 'единица измерения', dataIndex: 'unit' },
+  ]
+
   return (
     <div>
-      <Space style={{ marginBottom: 16 }}>
-        <Button onClick={handleSave}>Сохранить</Button>
-      </Space>
-      <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+        <Space>
+          <Button onClick={handleAdd}>Добавить</Button>
+          <Button onClick={handleShow}>Показать</Button>
+        </Space>
+      </div>
+      {mode === 'add' && (
+        <>
+          <Space style={{ marginBottom: 16 }}>
+            <Button onClick={handleSave}>Сохранить</Button>
+          </Space>
+          <Table<RowData> dataSource={rows} columns={columnsAdd} pagination={false} rowKey="key" />
+        </>
+      )}
+      {mode === 'show' && (
+        <Table<RowData> dataSource={rows} columns={columnsShow} pagination={false} rowKey="key" />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- добавить кнопки "Добавить" и "Показать" на страницу "Шахматка"
- реализовать режимы добавления и просмотра данных шахматки

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e09a94c0832ea178b5f847af4b22