### PR TITLE
fix: use new Supabase publishable key env var

### DIFF
--- a/portal_design.md
+++ b/portal_design.md
@@ -68,9 +68,13 @@ Dashboard
 ```ts
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY, {
-  auth: { persistSession: true }
-})
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY,
+  {
+    auth: { persistSession: true }
+  }
+)
 ```
 - Realtime: канал `Blueprintflow:{id}` для совместного редактирования с optimistic locking по `updated_at`.
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,9 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const url = import.meta.env.VITE_SUPABASE_URL
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY
+const key =
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+  import.meta.env.VITE_SUPABASE_ANON_KEY
 
 export const supabase: SupabaseClient | undefined =
   url && key ? createClient(url, key) : undefined


### PR DESCRIPTION
## Summary
- use `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY` for Supabase client
- document new Supabase key variable in portal design guide

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895eb7022a0832e9b2fcea1b89efbdc