### PR TITLE
feat: add CRUD actions for units reference

### DIFF
--- a/src/pages/references/Units.tsx
+++ b/src/pages/references/Units.tsx
@@ -1,5 +1,160 @@
-import DataTable from '../../components/DataTable'
+import { useState } from 'react'
+import {
+  App,
+  Button,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+} from 'antd'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
 
-const Units = () => <DataTable table="units" />
+interface Unit {
+  id: string
+  name: string
+  created_at: string
+}
 
-export default Units
+export default function Units() {
+  const { message } = App.useApp()
+  const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
+  const [currentUnit, setCurrentUnit] = useState<Unit | null>(null)
+  const [form] = Form.useForm()
+
+  const { data: units, isLoading, refetch } = useQuery({
+    queryKey: ['units'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase
+        .from('units')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) {
+        message.error('Не удалось загрузить данные')
+        throw error
+      }
+      return data as Unit[]
+    },
+  })
+
+  const openAddModal = () => {
+    form.resetFields()
+    setModalMode('add')
+  }
+
+  const openViewModal = (record: Unit) => {
+    setCurrentUnit(record)
+    setModalMode('view')
+  }
+
+  const openEditModal = (record: Unit) => {
+    setCurrentUnit(record)
+    form.setFieldsValue({ name: record.name })
+    setModalMode('edit')
+  }
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields()
+      if (!supabase) return
+      if (modalMode === 'add') {
+        const { error } = await supabase.from('units').insert({ name: values.name })
+        if (error) throw error
+        message.success('Запись добавлена')
+      }
+      if (modalMode === 'edit' && currentUnit) {
+        const { error } = await supabase
+          .from('units')
+          .update({ name: values.name })
+          .eq('id', currentUnit.id)
+        if (error) throw error
+        message.success('Запись обновлена')
+      }
+      setModalMode(null)
+      setCurrentUnit(null)
+      await refetch()
+    } catch {
+      message.error('Не удалось сохранить')
+    }
+  }
+
+  const handleDelete = async (record: Unit) => {
+    if (!supabase) return
+    const { error } = await supabase.from('units').delete().eq('id', record.id)
+    if (error) {
+      message.error('Не удалось удалить')
+    } else {
+      message.success('Запись удалена')
+      refetch()
+    }
+  }
+
+  const columns = [
+    { title: 'Название', dataIndex: 'name' },
+    {
+      title: 'Действия',
+      dataIndex: 'actions',
+      render: (_: unknown, record: Unit) => (
+        <Space>
+          <Button onClick={() => openViewModal(record)}>Просмотр</Button>
+          <Button onClick={() => openEditModal(record)}>Редактировать</Button>
+          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
+            <Button danger>Удалить</Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ]
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+        <Button type="primary" onClick={openAddModal}>
+          Добавить
+        </Button>
+      </div>
+      <Table<Unit>
+        dataSource={units ?? []}
+        columns={columns}
+        rowKey="id"
+        loading={isLoading}
+      />
+
+      <Modal
+        open={modalMode !== null}
+        title={
+          modalMode === 'add'
+            ? 'Добавить единицу'
+            : modalMode === 'edit'
+              ? 'Редактировать единицу'
+              : 'Просмотр единицы'
+        }
+        onCancel={() => {
+          setModalMode(null)
+          setCurrentUnit(null)
+        }}
+        onOk={modalMode === 'view' ? () => setModalMode(null) : handleSave}
+        okText={modalMode === 'view' ? 'Закрыть' : 'Сохранить'}
+        cancelText="Отмена"
+      >
+        {modalMode === 'view' ? (
+          <p>{currentUnit?.name}</p>
+        ) : (
+          <Form form={form} layout="vertical">
+            <Form.Item
+              label="Название"
+              name="name"
+              rules={[{ required: true, message: 'Введите название' }]}
+            >
+              <Input />
+            </Form.Item>
+          </Form>
+        )}
+      </Modal>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add table controls to create, view, edit and delete units

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899a57057fc832e8d1b4946d915d026