### PR TITLE
feat: add CRUD for projects reference

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -161,6 +161,20 @@
     "column_default": null
   },
   {
+    "table_name": "projects",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "projects",
+    "column_name": "building_name",
+    "data_type": "character varying",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "reference_data",
     "column_name": "id",
     "data_type": "uuid",

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -1,107 +1,224 @@
 import { useState } from 'react'
-import { App, Button, Input, Space, Table } from 'antd'
-import { PlusOutlined } from '@ant-design/icons'
+import {
+  App,
+  Button,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+} from 'antd'
+import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 
-interface RowData {
-  key: string
+interface Project {
+  id: string
   name: string
+  description: string
+  address: string
+  buildingName: string
+  created_at: string
 }
 
-const emptyRow = (): RowData => ({ key: Math.random().toString(36).slice(2), name: '' })
-
 export default function Projects() {
-  const [mode, setMode] = useState<'add' | 'show' | null>(null)
-  const [rows, setRows] = useState<RowData[]>([])
-  const [viewRows, setViewRows] = useState<RowData[]>([])
   const { message } = App.useApp()
+  const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
+  const [currentProject, setCurrentProject] = useState<Project | null>(null)
+  const [form] = Form.useForm()
 
-  const addRow = () => setRows([...rows, emptyRow()])
-
-  const handleChange = (key: string, value: string) => {
-    setRows((prev) => prev.map((r) => (r.key === key ? { ...r, name: value } : r)))
-  }
-
-  const handleAddClick = () => {
-    setMode('add')
-    setRows([emptyRow()])
-  }
-
-  const handleShow = async () => {
-    setMode('show')
-    if (!supabase) {
-      setViewRows([])
-      return
-    }
-    const { data, error } = await supabase.from('projects').select('id, name').limit(100)
-    if (error) {
-      console.error('Error fetching projects:', error)
-      message.error('Не удалось загрузить данные')
-      setViewRows([])
-      return
-    }
-    setViewRows(
-      (data as { id: string; name: string }[] | null)?.map((p) => ({
-        key: p.id,
+  const { data: projects, isLoading, refetch } = useQuery({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase
+        .from('projects')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) {
+        message.error('Не удалось загрузить данные')
+        throw error
+      }
+      return (data as {
+        id: string
+        name: string
+        description: string
+        address: string
+        building_name: string
+        created_at: string
+      }[]).map((p) => ({
+        id: p.id,
         name: p.name,
-      })) ?? []
-    )
+        description: p.description,
+        address: p.address,
+        buildingName: p.building_name,
+        created_at: p.created_at,
+      }))
+    },
+  })
+
+  const openAddModal = () => {
+    form.resetFields()
+    setModalMode('add')
+  }
+
+  const openViewModal = (record: Project) => {
+    setCurrentProject(record)
+    setModalMode('view')
+  }
+
+  const openEditModal = (record: Project) => {
+    setCurrentProject(record)
+    form.setFieldsValue({
+      name: record.name,
+      description: record.description,
+      address: record.address,
+      buildingName: record.buildingName,
+    })
+    setModalMode('edit')
   }
 
   const handleSave = async () => {
-    if (!supabase) {
-      console.error('Supabase client is not configured')
-      return
+    try {
+      const values = await form.validateFields()
+      if (!supabase) return
+      if (modalMode === 'add') {
+        const { error } = await supabase.from('projects').insert({
+          name: values.name,
+          description: values.description,
+          address: values.address,
+          building_name: values.buildingName,
+        })
+        if (error) throw error
+        message.success('Запись добавлена')
+      }
+      if (modalMode === 'edit' && currentProject) {
+        const { error } = await supabase
+          .from('projects')
+          .update({
+            name: values.name,
+            description: values.description,
+            address: values.address,
+            building_name: values.buildingName,
+          })
+          .eq('id', currentProject.id)
+        if (error) throw error
+        message.success('Запись обновлена')
+      }
+      setModalMode(null)
+      setCurrentProject(null)
+      await refetch()
+    } catch {
+      message.error('Не удалось сохранить')
     }
-    const payload = rows.map(({ name }) => ({ name }))
-    const { error } = await supabase.from('projects').insert(payload)
+  }
+
+  const handleDelete = async (record: Project) => {
+    if (!supabase) return
+    const { error } = await supabase.from('projects').delete().eq('id', record.id)
     if (error) {
-      console.error('Error inserting projects:', error)
-      message.error(`Не удалось сохранить данные: ${error.message}`)
+      message.error('Не удалось удалить')
     } else {
-      message.success('Данные успешно сохранены')
+      message.success('Запись удалена')
+      refetch()
     }
   }
 
   const columns = [
+    { title: 'Название', dataIndex: 'name' },
+    { title: 'Описание', dataIndex: 'description' },
+    { title: 'Адрес', dataIndex: 'address' },
+    { title: 'Корпус', dataIndex: 'buildingName' },
     {
-      title: 'название',
-      dataIndex: 'name',
-      render: (_: unknown, record: RowData) => (
-        <Input value={record.name} onChange={(e) => handleChange(record.key, e.target.value)} />
+      title: 'Действия',
+      dataIndex: 'actions',
+      render: (_: unknown, record: Project) => (
+        <Space>
+          <Button onClick={() => openViewModal(record)}>Просмотр</Button>
+          <Button onClick={() => openEditModal(record)}>Редактировать</Button>
+          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
+            <Button danger>Удалить</Button>
+          </Popconfirm>
+        </Space>
       ),
     },
-    {
-      title: '',
-      dataIndex: 'actions',
-      render: (_: unknown, __: RowData, index: number) =>
-        index === rows.length - 1 ? (
-          <Button type="text" icon={<PlusOutlined />} onClick={addRow} />
-        ) : null,
-    },
   ]
-
-  const viewColumns = [{ title: 'название', dataIndex: 'name' }]
 
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
-        <Space>
-          <Button onClick={handleAddClick}>Добавить</Button>
-          <Button onClick={handleShow}>Показать</Button>
-        </Space>
+        <Button type="primary" onClick={openAddModal}>
+          Добавить
+        </Button>
       </div>
-      {mode === 'add' && (
-        <>
-          <Space style={{ marginBottom: 16 }}>
-            <Button onClick={handleSave}>Сохранить</Button>
-          </Space>
-          <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
-        </>
-      )}
-      {mode === 'show' && (
-        <Table<RowData> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
-      )}
+      <Table<Project>
+        dataSource={projects ?? []}
+        columns={columns}
+        rowKey="id"
+        loading={isLoading}
+      />
+
+      <Modal
+        open={modalMode !== null}
+        title={
+          modalMode === 'add'
+            ? 'Добавить проект'
+            : modalMode === 'edit'
+              ? 'Редактировать проект'
+              : 'Просмотр проекта'
+        }
+        onCancel={() => {
+          setModalMode(null)
+          setCurrentProject(null)
+        }}
+        onOk={modalMode === 'view' ? () => setModalMode(null) : handleSave}
+        okText={modalMode === 'view' ? 'Закрыть' : 'Сохранить'}
+        cancelText="Отмена"
+      >
+        {modalMode === 'view' ? (
+          <div>
+            <p><strong>Название:</strong> {currentProject?.name}</p>
+            <p><strong>Описание:</strong> {currentProject?.description}</p>
+            <p><strong>Адрес:</strong> {currentProject?.address}</p>
+            <p><strong>Корпус:</strong> {currentProject?.buildingName}</p>
+          </div>
+        ) : (
+          <Form form={form} layout="vertical">
+            <Form.Item
+              label="Название"
+              name="name"
+              rules={[{ required: true, message: 'Введите название' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Описание"
+              name="description"
+              rules={[{ required: true, message: 'Введите описание' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Адрес"
+              name="address"
+              rules={[{ required: true, message: 'Введите адрес' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Название корпуса"
+              name="buildingName"
+              rules={[
+                { required: true, message: 'Введите название корпуса' },
+                { max: 50, message: 'Максимум 50 символов' },
+              ]}
+            >
+              <Input />
+            </Form.Item>
+          </Form>
+        )}
+      </Modal>
     </div>
   )
 }
+

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,6 +1,9 @@
 create table if not exists projects (
   id uuid primary key default gen_random_uuid(),
   name text not null,
+  description text,
+  address text,
+  building_name varchar(50),
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- add full CRUD UI for project reference with description, address and building name fields
- extend `projects` schema with description, address and building_name columns
- document new columns in database structure

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899aba9c398832e8ed6fe57173ab003