### PR TITLE
feat: support multiple buildings per project

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -169,8 +169,15 @@
   },
   {
     "table_name": "projects",
-    "column_name": "building_name",
-    "data_type": "character varying",
+    "column_name": "building_count",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "projects",
+    "column_name": "building_names",
+    "data_type": "ARRAY",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/supabase.sql
+++ b/supabase.sql
@@ -3,7 +3,8 @@ create table if not exists projects (
   name text not null,
   description text,
   address text,
-  building_name varchar(50),
+  building_count integer,
+  building_names text[],
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- allow specifying multiple building names for projects
- store building count and names in projects table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899aed25ee8832eb1dbba378da492c3