### PR TITLE
feat: support multiple buildings per project

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -169,8 +169,15 @@
   },
   {
     "table_name": "projects",
-    "column_name": "building_name",
-    "data_type": "character varying",
+    "column_name": "building_count",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "projects",
+    "column_name": "building_names",
+    "data_type": "ARRAY",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Form,
   Input,
+  InputNumber,
   Modal,
   Popconfirm,
   Space,
@@ -17,7 +18,8 @@ interface Project {
   name: string
   description: string
   address: string
-  buildingName: string
+  buildingCount: number
+  buildingNames: string[]
   created_at: string
 }
 
@@ -26,6 +28,8 @@ export default function Projects() {
   const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
   const [currentProject, setCurrentProject] = useState<Project | null>(null)
   const [form] = Form.useForm()
+
+  const buildingCount = Form.useWatch('buildingCount', form) || 0
 
   const { data: projects, isLoading, refetch } = useQuery({
     queryKey: ['projects'],
@@ -44,18 +48,20 @@ export default function Projects() {
         name: string
         description: string
         address: string
-        building_name: string
+        building_count: number | null
+        building_names: string[] | null
         created_at: string
       }[]).map((p) => ({
-        id: p.id,
-        name: p.name,
-        description: p.description,
-        address: p.address,
-        buildingName: p.building_name,
-        created_at: p.created_at,
-      }))
-    },
-  })
+          id: p.id,
+          name: p.name,
+          description: p.description,
+          address: p.address,
+          buildingCount: p.building_count ?? 0,
+          buildingNames: p.building_names ?? [],
+          created_at: p.created_at,
+        }))
+      },
+    })
 
   const openAddModal = () => {
     form.resetFields()
@@ -73,7 +79,8 @@ export default function Projects() {
       name: record.name,
       description: record.description,
       address: record.address,
-      buildingName: record.buildingName,
+      buildingCount: record.buildingCount,
+      buildingNames: record.buildingNames,
     })
     setModalMode('edit')
   }
@@ -87,7 +94,8 @@ export default function Projects() {
           name: values.name,
           description: values.description,
           address: values.address,
-          building_name: values.buildingName,
+          building_count: values.buildingCount,
+          building_names: (values.buildingNames || []).slice(0, values.buildingCount),
         })
         if (error) throw error
         message.success('Запись добавлена')
@@ -99,7 +107,8 @@ export default function Projects() {
             name: values.name,
             description: values.description,
             address: values.address,
-            building_name: values.buildingName,
+            building_count: values.buildingCount,
+            building_names: (values.buildingNames || []).slice(0, values.buildingCount),
           })
           .eq('id', currentProject.id)
         if (error) throw error
@@ -128,7 +137,12 @@ export default function Projects() {
     { title: 'Название', dataIndex: 'name' },
     { title: 'Описание', dataIndex: 'description' },
     { title: 'Адрес', dataIndex: 'address' },
-    { title: 'Корпус', dataIndex: 'buildingName' },
+    { title: 'Количество корпусов', dataIndex: 'buildingCount' },
+    {
+      title: 'Корпуса',
+      dataIndex: 'buildingNames',
+      render: (names: string[]) => names.join(', '),
+    },
     {
       title: 'Действия',
       dataIndex: 'actions',
@@ -180,7 +194,10 @@ export default function Projects() {
             <p><strong>Название:</strong> {currentProject?.name}</p>
             <p><strong>Описание:</strong> {currentProject?.description}</p>
             <p><strong>Адрес:</strong> {currentProject?.address}</p>
-            <p><strong>Корпус:</strong> {currentProject?.buildingName}</p>
+            <p><strong>Количество корпусов:</strong> {currentProject?.buildingCount}</p>
+            <p>
+              <strong>Корпуса:</strong> {currentProject?.buildingNames.join(', ')}
+            </p>
           </div>
         ) : (
           <Form form={form} layout="vertical">
@@ -206,15 +223,25 @@ export default function Projects() {
               <Input />
             </Form.Item>
             <Form.Item
-              label="Название корпуса"
-              name="buildingName"
-              rules={[
-                { required: true, message: 'Введите название корпуса' },
-                { max: 50, message: 'Максимум 50 символов' },
-              ]}
+              label="Количество корпусов"
+              name="buildingCount"
+              rules={[{ required: true, message: 'Введите количество корпусов' }]}
             >
-              <Input />
+              <InputNumber min={1} />
             </Form.Item>
+            {Array.from({ length: buildingCount }).map((_, index) => (
+              <Form.Item
+                key={index}
+                label={`Название корпуса ${index + 1}`}
+                name={['buildingNames', index]}
+                rules={[
+                  { required: true, message: 'Введите название корпуса' },
+                  { max: 50, message: 'Максимум 50 символов' },
+                ]}
+              >
+                <Input />
+              </Form.Item>
+            ))}
           </Form>
         )}
       </Modal>

--- a/supabase.sql
+++ b/supabase.sql
@@ -3,7 +3,8 @@ create table if not exists projects (
   name text not null,
   description text,
   address text,
-  building_name varchar(50),
+  building_count integer,
+  building_names text[],
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- allow specifying multiple building names for projects
- store building count and names in projects table
- render building name inputs dynamically based on building count

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899aed25ee8832eb1dbba378da492c3