### PR TITLE
feat: select units from dictionary in chessboard

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -27,23 +27,23 @@ create table if not exists estimate_items (
 
 create table chessboard (
   id uuid primary key default gen_random_uuid(),
-  project text,
+  project_id uuid references projects on delete cascade,
   material text,
   "quantityPd" numeric,
   "quantitySpec" numeric,
   "quantityRd" numeric,
-  unit text,
+  unit_id uuid references units on delete set null,
   created_at timestamptz default now()
 );
 
 create table if not exists chessboard (
   id uuid primary key default gen_random_uuid(),
-  project text,
+  project_id uuid references projects on delete cascade,
   material text,
   "quantityPd" numeric,
   "quantitySpec" numeric,
   "quantityRd" numeric,
-  unit text,
+  unit_id uuid references units on delete set null,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- load units reference and use select for unit in chessboard entries
- update chessboard schema with unit_id reference

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b70298b8832e96a893918b4f5f8e