### PR TITLE
feat: add cost category to chessboard

### DIFF
--- a/sql/add_cost_category_to_chessboard.sql
+++ b/sql/add_cost_category_to_chessboard.sql
@@ -1,0 +1,26 @@
+-- Добавление категории затрат в шахматку и заполнение значений по умолчанию
+create table if not exists cost_categories (
+  id uuid primary key default gen_random_uuid(),
+  parent_id uuid references cost_categories on delete set null,
+  code text unique not null,
+  name text not null,
+  level int check (level in (1, 2, 3)) not null,
+  description text,
+  created_at timestamptz default now()
+);
+
+create view if not exists cost_categories_sorted as
+select *
+from cost_categories
+order by code asc;
+
+alter table if exists chessboard
+  add column if not exists cost_category_code text references cost_categories(code);
+
+insert into cost_categories (code, name, level)
+values ('99', 'Прочее', 1)
+on conflict (code) do nothing;
+
+update chessboard
+set cost_category_code = '99'
+where cost_category_code is null;

--- a/supabase.sql
+++ b/supabase.sql
@@ -33,6 +33,7 @@ create table chessboard (
   "quantitySpec" numeric,
   "quantityRd" numeric,
   unit_id uuid references units on delete set null,
+  cost_category_code text references cost_categories(code),
   created_at timestamptz default now()
 );
 
@@ -44,6 +45,7 @@ create table if not exists chessboard (
   "quantitySpec" numeric,
   "quantityRd" numeric,
   unit_id uuid references units on delete set null,
+  cost_category_code text references cost_categories(code),
   created_at timestamptz default now()
 );
 
@@ -83,3 +85,19 @@ create table if not exists cost_categories (
   description text,
   created_at timestamptz default now()
 );
+
+create view if not exists cost_categories_sorted as
+select *
+from cost_categories
+order by code asc;
+
+alter table if exists chessboard
+add column if not exists cost_category_code text references cost_categories(code);
+
+insert into cost_categories (code, name, level)
+values ('99', 'Прочее', 1)
+on conflict (code) do nothing;
+
+update chessboard
+set cost_category_code = '99'
+where cost_category_code is null;


### PR DESCRIPTION
## Summary
- add migration SQL for chessboard cost categories
- allow selecting cost category per chessboard row

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d5dd96a0832eb266a11c8ab7e327