### PR TITLE
fix: ensure 8ch min width for numeric chessboard inputs

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -211,21 +211,33 @@ export default function Chessboard() {
       title: 'Кол-во по ПД',
       dataIndex: 'quantityPd',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantityPd} onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)} />
+        <Input
+          style={{ minWidth: '8ch' }}
+          value={record.quantityPd}
+          onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)}
+        />
       ),
     },
     {
       title: 'Кол-во по спеке РД',
       dataIndex: 'quantitySpec',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantitySpec} onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)} />
+        <Input
+          style={{ minWidth: '8ch' }}
+          value={record.quantitySpec}
+          onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)}
+        />
       ),
     },
     {
       title: 'Кол-во по пересчету РД',
       dataIndex: 'quantityRd',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantityRd} onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)} />
+        <Input
+          style={{ minWidth: '8ch' }}
+          value={record.quantityRd}
+          onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)}
+        />
       ),
     },
     {


### PR DESCRIPTION
## Summary
- enforce minimum width of eight characters for numeric fields in chessboard entry form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e5a13fd8832e9bda71ac4e9b66cc