### PR TITLE
fix: adjust chessboard quantity input width

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -211,21 +211,33 @@ export default function Chessboard() {
       title: 'Кол-во по ПД',
       dataIndex: 'quantityPd',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantityPd} onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)} />
+        <Input
+          style={{ width: '10ch' }}
+          value={record.quantityPd}
+          onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)}
+        />
       ),
     },
     {
       title: 'Кол-во по спеке РД',
       dataIndex: 'quantitySpec',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantitySpec} onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)} />
+        <Input
+          style={{ width: '10ch' }}
+          value={record.quantitySpec}
+          onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)}
+        />
       ),
     },
     {
       title: 'Кол-во по пересчету РД',
       dataIndex: 'quantityRd',
       render: (_: unknown, record: RowData) => (
-        <Input value={record.quantityRd} onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)} />
+        <Input
+          style={{ width: '10ch' }}
+          value={record.quantityRd}
+          onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)}
+        />
       ),
     },
     {


### PR DESCRIPTION
## Summary
- limit chessboard quantity inputs to 10 characters

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899ec1fadd0832e9b31202ae8aa8af7