### PR TITLE
feat: add floors and block mapping for projects

### DIFF
--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -19,8 +19,11 @@ interface Project {
   name: string
   description: string
   address: string
-  buildingCount: number
+  undergroundFloor: number
+  abovegroundFloor: number
   buildingNames: string[]
+  blockIds: string[]
+  buildingCount: number
   created_at: string
 }
 
@@ -38,29 +41,29 @@ export default function Projects() {
       if (!supabase) return []
       const { data, error } = await supabase
         .from('projects')
-        .select('*')
+        .select('id, name, description, address, underground_floor, aboveground_floor, created_at, projects_blocks(blocks(id, name))')
         .order('created_at', { ascending: false })
       if (error) {
         message.error('Не удалось загрузить данные')
         throw error
       }
-      return (data as {
-        id: string
-        name: string
-        description: string
-        address: string
-        building_count: number | null
-        building_names: string[] | null
-        created_at: string
-      }[]).map((p) => ({
-          id: p.id,
-          name: p.name,
-          description: p.description,
-          address: p.address,
-          buildingCount: p.building_count ?? 0,
-          buildingNames: p.building_names ?? [],
-          created_at: p.created_at,
-        }))
+      return (data as any[]).map((p) => {
+          const blocks = (p.projects_blocks ?? []).map((pb: any) => pb.blocks).filter(Boolean)
+          const buildingNames = blocks.map((b: any) => b.name as string)
+          const blockIds = blocks.map((b: any) => b.id as string)
+          return {
+            id: p.id as string,
+            name: p.name as string,
+            description: p.description as string,
+            address: p.address as string,
+            undergroundFloor: (p.underground_floor as number | null) ?? 0,
+            abovegroundFloor: (p.aboveground_floor as number | null) ?? 0,
+            buildingNames,
+            blockIds,
+            buildingCount: buildingNames.length,
+            created_at: p.created_at as string,
+          }
+        })
       },
     })
 
@@ -80,6 +83,8 @@ export default function Projects() {
       name: record.name,
       description: record.description,
       address: record.address,
+      undergroundFloor: record.undergroundFloor,
+      abovegroundFloor: record.abovegroundFloor,
       buildingCount: record.buildingCount,
       buildingNames: record.buildingNames,
     })
@@ -90,29 +95,62 @@ export default function Projects() {
     try {
       const values = await form.validateFields()
       if (!supabase) return
+      const names: string[] = (values.buildingNames || []).slice(0, values.buildingCount)
       if (modalMode === 'add') {
-        const { error } = await supabase.from('projects').insert({
-          name: values.name,
-          description: values.description,
-          address: values.address,
-          building_count: values.buildingCount,
-          building_names: (values.buildingNames || []).slice(0, values.buildingCount),
-        })
-        if (error) throw error
+        const { data: projectData, error: projectError } = await supabase
+          .from('projects')
+          .insert({
+            name: values.name,
+            description: values.description,
+            address: values.address,
+            underground_floor: values.undergroundFloor,
+            aboveground_floor: values.abovegroundFloor,
+          })
+          .select('id')
+          .single()
+        if (projectError) throw projectError
+        for (const name of names) {
+          const { data: blockData, error: blockError } = await supabase
+            .from('blocks')
+            .insert({ name })
+            .select('id')
+            .single()
+          if (blockError) throw blockError
+          const { error: mapError } = await supabase
+            .from('projects_blocks')
+            .insert({ project_id: projectData.id, block_id: blockData.id })
+          if (mapError) throw mapError
+        }
         message.success('Запись добавлена')
       }
       if (modalMode === 'edit' && currentProject) {
-        const { error } = await supabase
+        const { error: updateError } = await supabase
           .from('projects')
           .update({
             name: values.name,
             description: values.description,
             address: values.address,
-            building_count: values.buildingCount,
-            building_names: (values.buildingNames || []).slice(0, values.buildingCount),
+            underground_floor: values.undergroundFloor,
+            aboveground_floor: values.abovegroundFloor,
           })
           .eq('id', currentProject.id)
-        if (error) throw error
+        if (updateError) throw updateError
+        if (currentProject.blockIds.length > 0) {
+          await supabase.from('projects_blocks').delete().eq('project_id', currentProject.id)
+          await supabase.from('blocks').delete().in('id', currentProject.blockIds)
+        }
+        for (const name of names) {
+          const { data: blockData, error: blockError } = await supabase
+            .from('blocks')
+            .insert({ name })
+            .select('id')
+            .single()
+          if (blockError) throw blockError
+          const { error: mapError } = await supabase
+            .from('projects_blocks')
+            .insert({ project_id: currentProject.id, block_id: blockData.id })
+          if (mapError) throw mapError
+        }
         message.success('Запись обновлена')
       }
       setModalMode(null)
@@ -125,12 +163,17 @@ export default function Projects() {
 
   const handleDelete = async (record: Project) => {
     if (!supabase) return
-    const { error } = await supabase.from('projects').delete().eq('id', record.id)
-    if (error) {
-      message.error('Не удалось удалить')
-    } else {
+    try {
+      if (record.blockIds.length > 0) {
+        await supabase.from('projects_blocks').delete().eq('project_id', record.id)
+        await supabase.from('blocks').delete().in('id', record.blockIds)
+      }
+      const { error } = await supabase.from('projects').delete().eq('id', record.id)
+      if (error) throw error
       message.success('Запись удалена')
       refetch()
+    } catch {
+      message.error('Не удалось удалить')
     }
   }
 
@@ -161,6 +204,24 @@ export default function Projects() {
     [projects],
   )
 
+  const undergroundFloorFilters = useMemo(
+    () =>
+      Array.from(new Set((projects ?? []).map((p) => p.undergroundFloor))).map((f) => ({
+        text: String(f),
+        value: f,
+      })),
+    [projects],
+  )
+
+  const abovegroundFloorFilters = useMemo(
+    () =>
+      Array.from(new Set((projects ?? []).map((p) => p.abovegroundFloor))).map((f) => ({
+        text: String(f),
+        value: f,
+      })),
+    [projects],
+  )
+
   const buildingCountFilters = useMemo(
     () =>
       Array.from(new Set((projects ?? []).map((p) => p.buildingCount))).map((c) => ({
@@ -172,8 +233,8 @@ export default function Projects() {
 
   const buildingNameFilters = useMemo(() => {
     const names = new Set<string>()
-    ;(projects ?? []).forEach((p) => p.buildingNames.forEach((n) => names.add(n)))
-    return Array.from(names).map((n) => ({ text: n, value: n }))
+    ;(projects ?? []).forEach((p) => p.buildingNames.forEach((n: string) => names.add(n)))
+    return Array.from(names).map((n: string) => ({ text: n, value: n }))
   }, [projects])
 
   const columns = [
@@ -197,6 +258,20 @@ export default function Projects() {
       sorter: (a: Project, b: Project) => a.address.localeCompare(b.address),
       filters: addressFilters,
       onFilter: (value: unknown, record: Project) => record.address === value,
+    },
+    {
+      title: 'Нижний подземный этаж',
+      dataIndex: 'undergroundFloor',
+      sorter: (a: Project, b: Project) => a.undergroundFloor - b.undergroundFloor,
+      filters: undergroundFloorFilters,
+      onFilter: (value: unknown, record: Project) => record.undergroundFloor === value,
+    },
+    {
+      title: 'Верхний надземный этаж',
+      dataIndex: 'abovegroundFloor',
+      sorter: (a: Project, b: Project) => a.abovegroundFloor - b.abovegroundFloor,
+      filters: abovegroundFloorFilters,
+      onFilter: (value: unknown, record: Project) => record.abovegroundFloor === value,
     },
     {
       title: 'Количество корпусов',
@@ -274,6 +349,12 @@ export default function Projects() {
             <p><strong>Название:</strong> {currentProject?.name}</p>
             <p><strong>Описание:</strong> {currentProject?.description}</p>
             <p><strong>Адрес:</strong> {currentProject?.address}</p>
+            <p>
+              <strong>Нижний подземный этаж:</strong> {currentProject?.undergroundFloor}
+            </p>
+            <p>
+              <strong>Верхний надземный этаж:</strong> {currentProject?.abovegroundFloor}
+            </p>
             <p><strong>Количество корпусов:</strong> {currentProject?.buildingCount}</p>
             <p>
               <strong>Корпуса:</strong> {currentProject?.buildingNames.join(', ')}
@@ -301,6 +382,20 @@ export default function Projects() {
               rules={[{ required: true, message: 'Введите адрес' }]}
             >
               <Input />
+            </Form.Item>
+            <Form.Item
+              label="Нижний подземный этаж"
+              name="undergroundFloor"
+              rules={[{ required: true, message: 'Введите нижний этаж' }]}
+            >
+              <InputNumber />
+            </Form.Item>
+            <Form.Item
+              label="Верхний надземный этаж"
+              name="abovegroundFloor"
+              rules={[{ required: true, message: 'Введите верхний этаж' }]}
+            >
+              <InputNumber />
             </Form.Item>
             <Form.Item
               label="Количество корпусов"

--- a/supabase.sql
+++ b/supabase.sql
@@ -3,10 +3,30 @@ create table if not exists projects (
   name text not null,
   description text,
   address text,
-  building_count integer,
-  building_names text[],
+  underground_floor integer,
+  aboveground_floor integer,
   created_at timestamptz default now()
 );
+
+create table if not exists blocks (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists projects_blocks (
+  project_id uuid references projects on delete cascade,
+  block_id uuid references blocks on delete cascade,
+  primary key (project_id, block_id)
+);
+
+create table if not exists floors (
+  number integer primary key
+);
+
+insert into floors (number)
+select generate_series(-3, 120)
+on conflict (number) do nothing;
 
 create table if not exists estimates (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- add underground/aboveground floor fields for projects
- persist project blocks via separate mapping table
- define DB tables for projects, blocks, and floors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b30c869f0832e9dc4cd84e605ae35