### PR TITLE
feat: split projects into blocks and floors

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -169,15 +169,15 @@
   },
   {
     "table_name": "projects",
-    "column_name": "building_count",
+    "column_name": "bottom_underground_floor",
     "data_type": "integer",
     "is_nullable": "YES",
     "column_default": null
   },
   {
     "table_name": "projects",
-    "column_name": "building_names",
-    "data_type": "ARRAY",
+    "column_name": "top_ground_floor",
+    "data_type": "integer",
     "is_nullable": "YES",
     "column_default": null
   },
@@ -327,5 +327,40 @@
     "data_type": "timestamp with time zone",
     "is_nullable": "NO",
     "column_default": "now()"
+  },
+  {
+    "table_name": "floors",
+    "column_name": "number",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "blocks",
+    "column_name": "id",
+    "data_type": "uuid",
+    "is_nullable": "NO",
+    "column_default": "gen_random_uuid()"
+  },
+  {
+    "table_name": "blocks",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "projects_blocks",
+    "column_name": "project_id",
+    "data_type": "uuid",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "projects_blocks",
+    "column_name": "block_id",
+    "data_type": "uuid",
+    "is_nullable": "NO",
+    "column_default": null
   }
 ]

--- a/sql/migrate_projects_blocks_and_floors.sql
+++ b/sql/migrate_projects_blocks_and_floors.sql
@@ -1,0 +1,22 @@
+-- Миграция корпусов из projects и заполнение крайних этажей
+-- Переносим уникальные названия корпусов в таблицу blocks
+insert into blocks (name)
+select distinct unnest(building_names) as name
+from projects
+where building_names is not null
+on conflict do nothing;
+
+-- Заполняем таблицу маппинга projects_blocks
+insert into projects_blocks (project_id, block_id)
+select p.id, b.id
+from projects p
+cross join unnest(p.building_names) as bn(name)
+join blocks b on b.name = bn.name
+on conflict do nothing;
+
+-- Записываем минимальный и максимальный этажи в проекты
+update projects
+set bottom_underground_floor = (select min(number) from floors),
+    top_ground_floor = (select max(number) from floors)
+where bottom_underground_floor is null
+   or top_ground_floor is null;

--- a/supabase.sql
+++ b/supabase.sql
@@ -3,10 +3,56 @@ create table if not exists projects (
   name text not null,
   description text,
   address text,
-  building_count integer,
-  building_names text[],
+  bottom_underground_floor integer,
+  top_ground_floor integer,
   created_at timestamptz default now()
 );
+
+create table if not exists floors (
+  number integer primary key
+);
+
+insert into floors (number)
+select generate_series(-3, 120)
+on conflict do nothing;
+
+create table if not exists blocks (
+  id uuid primary key default gen_random_uuid(),
+  name text not null
+);
+
+create table if not exists projects_blocks (
+  project_id uuid references projects on delete cascade,
+  block_id uuid references blocks on delete cascade,
+  primary key (project_id, block_id)
+);
+
+alter table if exists projects
+  add column if not exists bottom_underground_floor integer,
+  add column if not exists top_ground_floor integer;
+
+-- перенос корпусов из массива projects.building_names в отдельные таблицы
+insert into blocks (name)
+select distinct unnest(building_names) as name
+from projects
+where building_names is not null;
+
+insert into projects_blocks (project_id, block_id)
+select p.id, b.id
+from projects p
+cross join unnest(p.building_names) as bn(name)
+join blocks b on b.name = bn.name
+on conflict do nothing;
+
+update projects
+set bottom_underground_floor = (select min(number) from floors),
+    top_ground_floor = (select max(number) from floors)
+where bottom_underground_floor is null
+   or top_ground_floor is null;
+
+alter table if exists projects
+  drop column if exists building_names,
+  drop column if exists building_count;
 
 create table if not exists estimates (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- добавить поля ввода нижнего и верхнего этажей в справочник проектов
- сохранять корпуса проектов в отдельные таблицы blocks и projects_blocks
- обновить структуру БД и SQL скрипт, добавить миграцию существующих данных
- добавить SQL скрипт миграции для переноса корпусов и этажей

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b30c869f0832e9dc4cd84e605ae35