### PR TITLE
feat: добавить справочник видов работ с импортом

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -418,5 +418,47 @@
     "data_type": "timestamp with time zone",
     "is_nullable": "NO",
     "column_default": "now()"
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "id",
+    "data_type": "uuid",
+    "is_nullable": "NO",
+    "column_default": "gen_random_uuid()"
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "uid",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "unit",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "cost",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "work_types",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "now()"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "antd": "^5.21.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2147,6 +2148,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2347,6 +2357,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2369,6 +2392,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2417,6 +2449,18 @@
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2858,6 +2902,15 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4226,6 +4279,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -4589,6 +4654,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4618,6 +4701,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "antd": "^5.21.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import References from './pages/References'
 import Units from './pages/references/Units'
 import Projects from './pages/references/Projects'
 import CostCategories from './pages/references/CostCategories'
+import WorkTypes from './pages/references/WorkTypes'
 import PortalHeader from './components/PortalHeader'
 
 const { Sider, Content } = Layout
@@ -33,6 +34,7 @@ const App = () => {
           key: 'cost-categories',
           label: <Link to="/references/cost-categories">Категории затрат</Link>,
         },
+        { key: 'work-types', label: <Link to="/references/work-types">Виды работ</Link> },
       ],
     },
   ]
@@ -56,6 +58,7 @@ const App = () => {
               <Route index element={<Units />} />
               <Route path="projects" element={<Projects />} />
               <Route path="cost-categories" element={<CostCategories />} />
+              <Route path="work-types" element={<WorkTypes />} />
             </Route>
           </Routes>
         </Content>

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -26,6 +26,17 @@ interface Project {
   created_at: string
 }
 
+interface ProjectRow {
+  id: string
+  name: string
+  description: string | null
+  address: string | null
+  bottom_underground_floor: number | null
+  top_ground_floor: number | null
+  created_at: string
+  projects_blocks: { blocks: { name: string | null } | null }[] | null
+}
+
 export default function Projects() {
   const { message } = App.useApp()
   const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
@@ -48,18 +59,23 @@ export default function Projects() {
         message.error('Не удалось загрузить данные')
         throw error
       }
-      return (data as any[]).map((p) => ({
-          id: p.id,
-          name: p.name,
-          description: p.description,
-          address: p.address,
-          bottomUndergroundFloor: p.bottom_underground_floor ?? 0,
-          topGroundFloor: p.top_ground_floor ?? 0,
+      return ((data ?? []) as unknown[]).map((p) => {
+        const row = p as ProjectRow
+        return {
+          id: row.id,
+          name: row.name,
+          description: row.description ?? '',
+          address: row.address ?? '',
+          bottomUndergroundFloor: row.bottom_underground_floor ?? 0,
+          topGroundFloor: row.top_ground_floor ?? 0,
           buildingNames:
-            p.projects_blocks?.map((pb: any) => pb.blocks?.name ?? '').filter(Boolean) ?? [],
-          buildingCount: p.projects_blocks?.length ?? 0,
-          created_at: p.created_at,
-        }))
+            row.projects_blocks
+              ?.map((pb) => pb.blocks?.name ?? '')
+              .filter((n): n is string => !!n) ?? [],
+          buildingCount: row.projects_blocks?.length ?? 0,
+          created_at: row.created_at,
+        }
+      })
       },
     })
 
@@ -204,7 +220,13 @@ export default function Projects() {
 
   const descriptionFilters = useMemo(
     () =>
-      Array.from(new Set((projects ?? []).map((p) => p.description))).map((d) => ({
+      Array.from(
+        new Set(
+          (projects ?? [])
+            .map((p) => p.description)
+            .filter((d): d is string => !!d),
+        ),
+      ).map((d) => ({
         text: d,
         value: d,
       })),
@@ -213,7 +235,13 @@ export default function Projects() {
 
   const addressFilters = useMemo(
     () =>
-      Array.from(new Set((projects ?? []).map((p) => p.address))).map((a) => ({
+      Array.from(
+        new Set(
+          (projects ?? [])
+            .map((p) => p.address)
+            .filter((a): a is string => !!a),
+        ),
+      ).map((a) => ({
         text: a,
         value: a,
       })),

--- a/src/pages/references/WorkTypes.tsx
+++ b/src/pages/references/WorkTypes.tsx
@@ -1,0 +1,300 @@
+import { useMemo, useState } from 'react'
+import {
+  App,
+  Button,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+  Upload,
+} from 'antd'
+import type { UploadProps } from 'antd'
+import { UploadOutlined, EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
+import * as XLSX from 'xlsx'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+
+interface WorkType {
+  id: string
+  uid: string
+  name: string
+  unit: string
+  cost: number
+  created_at: string
+}
+
+export default function WorkTypes() {
+  const { message } = App.useApp()
+  const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
+  const [currentWorkType, setCurrentWorkType] = useState<WorkType | null>(null)
+  const [form] = Form.useForm()
+
+  const { data: workTypes, isLoading, refetch } = useQuery({
+    queryKey: ['work-types'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase
+        .from('work_types')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) {
+        message.error('Не удалось загрузить данные')
+        throw error
+      }
+      return data as WorkType[]
+    },
+  })
+
+  const openAddModal = () => {
+    form.resetFields()
+    setModalMode('add')
+  }
+
+  const openViewModal = (record: WorkType) => {
+    setCurrentWorkType(record)
+    setModalMode('view')
+  }
+
+  const openEditModal = (record: WorkType) => {
+    setCurrentWorkType(record)
+    form.setFieldsValue({
+      uid: record.uid,
+      name: record.name,
+      unit: record.unit,
+      cost: record.cost,
+    })
+    setModalMode('edit')
+  }
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields()
+      if (!supabase) return
+      if (modalMode === 'add') {
+        const { error } = await supabase
+          .from('work_types')
+          .insert({
+            uid: values.uid,
+            name: values.name,
+            unit: values.unit,
+            cost: values.cost,
+          })
+        if (error) throw error
+        message.success('Запись добавлена')
+      }
+      if (modalMode === 'edit' && currentWorkType) {
+        const { error } = await supabase
+          .from('work_types')
+          .update({
+            uid: values.uid,
+            name: values.name,
+            unit: values.unit,
+            cost: values.cost,
+          })
+          .eq('id', currentWorkType.id)
+        if (error) throw error
+        message.success('Запись обновлена')
+      }
+      setModalMode(null)
+      setCurrentWorkType(null)
+      await refetch()
+    } catch {
+      message.error('Не удалось сохранить')
+    }
+  }
+
+  const handleDelete = async (record: WorkType) => {
+    if (!supabase) return
+    const { error } = await supabase.from('work_types').delete().eq('id', record.id)
+    if (error) {
+      message.error('Не удалось удалить')
+    } else {
+      message.success('Запись удалена')
+      refetch()
+    }
+  }
+
+  const handleImport: UploadProps['beforeUpload'] = async (file) => {
+    try {
+      if (!supabase) return false
+      const data = await file.arrayBuffer()
+      const workbook = XLSX.read(data, { type: 'array' })
+      const sheet = workbook.Sheets[workbook.SheetNames[0]]
+      const json: Record<string, unknown>[] = XLSX.utils.sheet_to_json(sheet)
+      for (const row of json) {
+        const uid = String(row.uid ?? row.UID ?? '')
+        const name = String(row.name ?? '')
+        const unit = String(row.unit ?? '')
+        const cost = Number(row.cost ?? 0)
+        if (uid && name && unit) {
+          await supabase
+            .from('work_types')
+            .insert({ uid, name, unit, cost })
+        }
+      }
+      message.success('Импорт завершён')
+      refetch()
+    } catch {
+      message.error('Не удалось импортировать файл')
+    }
+    return false
+  }
+
+  const uidFilters = useMemo(
+    () =>
+      Array.from(new Set((workTypes ?? []).map((w) => w.uid))).map((u) => ({
+        text: u,
+        value: u,
+      })),
+    [workTypes],
+  )
+
+  const nameFilters = useMemo(
+    () =>
+      Array.from(new Set((workTypes ?? []).map((w) => w.name))).map((n) => ({
+        text: n,
+        value: n,
+      })),
+    [workTypes],
+  )
+
+  const unitFilters = useMemo(
+    () =>
+      Array.from(new Set((workTypes ?? []).map((w) => w.unit))).map((u) => ({
+        text: u,
+        value: u,
+      })),
+    [workTypes],
+  )
+
+  const columns = [
+    {
+      title: 'УИД',
+      dataIndex: 'uid',
+      sorter: (a: WorkType, b: WorkType) => a.uid.localeCompare(b.uid),
+      filters: uidFilters,
+      onFilter: (value: unknown, record: WorkType) => record.uid === value,
+    },
+    {
+      title: 'Наименование',
+      dataIndex: 'name',
+      sorter: (a: WorkType, b: WorkType) => a.name.localeCompare(b.name),
+      filters: nameFilters,
+      onFilter: (value: unknown, record: WorkType) => record.name === value,
+    },
+    {
+      title: 'Ед. изм.',
+      dataIndex: 'unit',
+      sorter: (a: WorkType, b: WorkType) => a.unit.localeCompare(b.unit),
+      filters: unitFilters,
+      onFilter: (value: unknown, record: WorkType) => record.unit === value,
+    },
+    {
+      title: 'Стоимость',
+      dataIndex: 'cost',
+      sorter: (a: WorkType, b: WorkType) => a.cost - b.cost,
+    },
+    {
+      title: 'Действия',
+      dataIndex: 'actions',
+      render: (_: unknown, record: WorkType) => (
+        <Space>
+          <Button
+            icon={<EyeOutlined />}
+            onClick={() => openViewModal(record)}
+            aria-label="Просмотр"
+          />
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => openEditModal(record)}
+            aria-label="Редактировать"
+          />
+          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
+            <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ]
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <Upload beforeUpload={handleImport} showUploadList={false} accept=".xlsx,.xls">
+          <Button icon={<UploadOutlined />}>Импорт из Excel</Button>
+        </Upload>
+        <Button type="primary" onClick={openAddModal}>
+          Добавить
+        </Button>
+      </div>
+      <Table<WorkType>
+        dataSource={workTypes ?? []}
+        columns={columns}
+        rowKey="id"
+        loading={isLoading}
+      />
+
+      <Modal
+        open={modalMode !== null}
+        title={
+          modalMode === 'add'
+            ? 'Добавить вид работ'
+            : modalMode === 'edit'
+              ? 'Редактировать вид работ'
+              : 'Просмотр вида работ'
+        }
+        onCancel={() => {
+          setModalMode(null)
+          setCurrentWorkType(null)
+        }}
+        onOk={modalMode === 'view' ? () => setModalMode(null) : handleSave}
+        okText={modalMode === 'view' ? 'Закрыть' : 'Сохранить'}
+        cancelText="Отмена"
+      >
+        {modalMode === 'view' ? (
+          <div>
+            <p>УИД: {currentWorkType?.uid}</p>
+            <p>Наименование: {currentWorkType?.name}</p>
+            <p>Ед. изм.: {currentWorkType?.unit}</p>
+            <p>Стоимость: {currentWorkType?.cost}</p>
+          </div>
+        ) : (
+          <Form form={form} layout="vertical">
+            <Form.Item
+              label="УИД"
+              name="uid"
+              rules={[{ required: true, message: 'Введите УИД' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Наименование"
+              name="name"
+              rules={[{ required: true, message: 'Введите наименование' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Ед. изм."
+              name="unit"
+              rules={[{ required: true, message: 'Введите единицу измерения' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Стоимость"
+              name="cost"
+              rules={[{ required: true, message: 'Введите стоимость' }]}
+            >
+              <InputNumber style={{ width: '100%' }} />
+            </Form.Item>
+          </Form>
+        )}
+      </Modal>
+    </div>
+  )
+}
+

--- a/supabase.sql
+++ b/supabase.sql
@@ -85,6 +85,15 @@ create table if not exists work_progress (
   completed_at timestamptz default now()
 );
 
+create table if not exists work_types (
+  id uuid primary key default gen_random_uuid(),
+  uid text unique not null,
+  name text not null,
+  unit text not null,
+  cost numeric not null,
+  created_at timestamptz default now()
+);
+
 create table if not exists units (
   id uuid primary key default gen_random_uuid(),
   name text unique not null,


### PR DESCRIPTION
## Summary
- add work types reference with CRUD and Excel import
- extend navigation and database schema for work types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b626caed0832ea4ec28731feb7278