### PR TITLE
feat: add dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,9 +39,9 @@ const App = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="light" style={{ background: '#e6f7ff' }} collapsible>
-        <div style={{ color: '#000', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
-        <Menu theme="light" mode="inline" items={items} />
+      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
+        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+        <Menu theme="dark" mode="inline" items={items} />
       </Sider>
       <Layout>
         <PortalHeader />

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -28,11 +28,12 @@ export default function PortalHeader() {
   return (
     <Header
       style={{
-        background: '#e6f7ff',
+        background: '#141414',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        color: '#fff',
       }}
     >
       <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
+  background-color: #000;
+  color: #fff;
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -38,10 +38,10 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const location = useLocation();
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="light" style={{ background: '#e6f7ff' }} collapsible>
-        <div style={{ color: '#000', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
+        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
-          theme="light"
+          theme="dark"
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ConfigProvider, App as AntdApp, unstableSetRender } from 'antd'
+import { ConfigProvider, App as AntdApp, unstableSetRender, theme } from 'antd'
 import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
@@ -21,10 +21,12 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ConfigProvider
       theme={{
+        algorithm: theme.darkAlgorithm,
         token: {
           colorPrimary: '#1677ff',
-          colorBgLayout: '#e6f7ff',
-          colorBgContainer: '#ffffff',
+          colorBgLayout: '#000000',
+          colorBgContainer: '#141414',
+          colorText: '#ffffff',
         },
       }}
     >

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -26,6 +26,17 @@ interface Project {
   created_at: string
 }
 
+interface ProjectRow {
+  id: string
+  name: string
+  description: string
+  address: string
+  bottom_underground_floor: number | null
+  top_ground_floor: number | null
+  created_at: string
+  projects_blocks: { blocks: { name: string | null } | null }[] | null
+}
+
 export default function Projects() {
   const { message } = App.useApp()
   const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
@@ -48,7 +59,7 @@ export default function Projects() {
         message.error('Не удалось загрузить данные')
         throw error
       }
-      return (data as any[]).map((p) => ({
+      return ((data ?? []) as unknown as ProjectRow[]).map((p) => ({
           id: p.id,
           name: p.name,
           description: p.description,
@@ -56,7 +67,7 @@ export default function Projects() {
           bottomUndergroundFloor: p.bottom_underground_floor ?? 0,
           topGroundFloor: p.top_ground_floor ?? 0,
           buildingNames:
-            p.projects_blocks?.map((pb: any) => pb.blocks?.name ?? '').filter(Boolean) ?? [],
+            p.projects_blocks?.map((pb) => pb.blocks?.name ?? '').filter(Boolean) ?? [],
           buildingCount: p.projects_blocks?.length ?? 0,
           created_at: p.created_at,
         }))


### PR DESCRIPTION
## Summary
- add Ant Design dark theme configuration
- switch layout and header to dark styling
- fix leftover any types in Projects list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b6760d6f083298ac10db3369d8070