### PR TITLE
feat: black and white dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,9 +46,22 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
-        <Menu theme="dark" mode="inline" items={items} />
+      <Sider
+        theme={isDark ? 'dark' : 'light'}
+        style={{ background: isDark ? '#000000' : '#ffffff' }}
+        collapsible
+      >
+        <div
+          style={{ color: isDark ? '#ffffff' : '#000000', padding: 16, fontWeight: 600 }}
+        >
+          BlueprintFlow
+        </div>
+        <Menu
+          theme={isDark ? 'dark' : 'light'}
+          mode="inline"
+          items={items}
+          style={{ background: isDark ? '#000000' : '#ffffff' }}
+        />
       </Sider>
       <Layout>
         <PortalHeader />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,9 +32,9 @@ export function Root() {
           ? {
               algorithm: theme.darkAlgorithm,
               token: {
-                colorPrimary: '#1677ff',
+                colorPrimary: '#ffffff',
                 colorBgLayout: '#000000',
-                colorBgContainer: '#141414',
+                colorBgContainer: '#000000',
                 colorText: '#ffffff',
               },
             }


### PR DESCRIPTION
## Summary
- update Ant Design tokens for black-and-white dark mode
- toggle sider and menu styles based on theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb1746488832e9ba4c919f0dbc661