### PR TITLE
feat: add monochrome dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,9 +46,17 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
-        <Menu theme="dark" mode="inline" items={items} />
+      <Sider
+        theme={isDark ? 'dark' : 'light'}
+        style={{ background: isDark ? '#000000' : '#ffffff' }}
+        collapsible
+      >
+        <div
+          style={{ color: isDark ? '#ffffff' : '#000000', padding: 16, fontWeight: 600 }}
+        >
+          BlueprintFlow
+        </div>
+        <Menu theme={isDark ? 'dark' : 'light'} mode="inline" items={items} />
       </Sider>
       <Layout>
         <PortalHeader />

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  background-color: #000;
-  color: #fff;
+  background-color: #fff;
+  color: #000;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,16 +32,16 @@ export function Root() {
           ? {
               algorithm: theme.darkAlgorithm,
               token: {
-                colorPrimary: '#1677ff',
+                colorPrimary: '#ffffff',
                 colorBgLayout: '#000000',
-                colorBgContainer: '#141414',
+                colorBgContainer: '#000000',
                 colorText: '#ffffff',
               },
             }
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#1677ff',
+                colorPrimary: '#000000',
                 colorBgLayout: '#ffffff',
                 colorBgContainer: '#ffffff',
                 colorText: '#000000',


### PR DESCRIPTION
## Summary
- switch dark mode to black-and-white palette
- update menu styling to follow current theme
- set light palette as default body style

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb1746488832e9ba4c919f0dbc661