### PR TITLE
fix: темная тема для бокового меню

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 
-import { Layout, Menu, Switch } from 'antd'
+import { Layout, Menu, Switch, theme } from 'antd'
 import { Link, Route, Routes } from 'react-router-dom'
 import Dashboard from './pages/Dashboard'
 import Documents from './pages/Documents'
@@ -20,6 +20,7 @@ interface AppProps {
 }
 
 const App = ({ isDark, toggleTheme }: AppProps) => {
+  const { token } = theme.useToken()
   const items = [
     { key: 'dashboard', label: <Link to="/">Dashboard</Link> },
     {
@@ -46,9 +47,18 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
-        <Menu theme="dark" mode="inline" items={items} />
+      <Sider
+        theme={isDark ? 'dark' : 'light'}
+        style={{ background: token.colorBgContainer }}
+        collapsible
+      >
+        <div style={{ color: token.colorText, padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+        <Menu
+          theme={isDark ? 'dark' : 'light'}
+          mode="inline"
+          items={items}
+          style={{ background: token.colorBgContainer }}
+        />
       </Sider>
       <Layout>
         <PortalHeader />

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,8 @@ body {
   background-color: #000;
   color: #fff;
 }
+
+.ant-menu-dark .ant-menu-submenu-popup,
+.ant-menu-dark .ant-menu-submenu-popup .ant-menu {
+  background: var(--ant-color-bg-container) !important;
+}

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, Menu } from 'antd';
+import { Layout, Menu, theme } from 'antd';
 import { Link, useLocation } from 'react-router-dom';
 import type { MenuProps } from 'antd';
 import PortalHeader from '../components/PortalHeader';
@@ -36,15 +36,22 @@ const items: MenuProps['items'] = [
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
+  const { token } = theme.useToken();
+  const isDark = token.colorBgContainer === '#141414';
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+      <Sider
+        theme={isDark ? 'dark' : 'light'}
+        style={{ background: token.colorBgContainer }}
+        collapsible
+      >
+        <div style={{ color: token.colorText, padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
-          theme="dark"
+          theme={isDark ? 'dark' : 'light'}
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}
+          style={{ background: token.colorBgContainer }}
         />
       </Sider>
       <Layout>


### PR DESCRIPTION
## Summary
- применить токены темы Ant Design для бокового меню
- стилизовать всплывающие подпункты меню в тёмном режиме

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c16fb8168832e9ed7322ff152bea8