### PR TITLE
fix: sync menu colors with dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 
-import { Layout, Menu, Switch } from 'antd'
+import { Layout, Menu, Switch, theme } from 'antd'
 import { Link, Route, Routes } from 'react-router-dom'
 import Dashboard from './pages/Dashboard'
 import Documents from './pages/Documents'
@@ -20,6 +20,8 @@ interface AppProps {
 }
 
 const App = ({ isDark, toggleTheme }: AppProps) => {
+  const { token } = theme.useToken()
+
   const items = [
     { key: 'dashboard', label: <Link to="/">Dashboard</Link> },
     {
@@ -46,9 +48,17 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
-        <Menu theme="dark" mode="inline" items={items} />
+      <Sider
+        theme={isDark ? 'dark' : 'light'}
+        style={{ background: token.colorBgContainer }}
+        collapsible
+      >
+        <div
+          style={{ color: token.colorText, padding: 16, fontWeight: 600 }}
+        >
+          BlueprintFlow
+        </div>
+        <Menu theme={isDark ? 'dark' : 'light'} mode="inline" items={items} />
       </Sider>
       <Layout>
         <PortalHeader />

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, Menu } from 'antd';
+import { Layout, Menu, theme } from 'antd';
 import { Link, useLocation } from 'react-router-dom';
 import type { MenuProps } from 'antd';
 import PortalHeader from '../components/PortalHeader';
@@ -36,12 +36,23 @@ const items: MenuProps['items'] = [
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
+  const { token } = theme.useToken();
+  const menuTheme = token.colorBgContainer === '#141414' ? 'dark' : 'light';
+
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+      <Sider
+        theme={menuTheme}
+        style={{ background: token.colorBgContainer }}
+        collapsible
+      >
+        <div
+          style={{ color: token.colorText, padding: 16, fontWeight: 600 }}
+        >
+          BlueprintFlow
+        </div>
         <Menu
-          theme="dark"
+          theme={menuTheme}
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}


### PR DESCRIPTION
## Summary
- propagate dark theme tokens to sidebar menu and popouts
- unify layout components with token-based colors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c16fb8168832e9ed7322ff152bea8