### PR TITLE
feat: adjust portal color themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,11 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
     <Layout style={{ minHeight: '100vh' }}>
       <Sider
         theme={isDark ? 'dark' : 'light'}
-        style={{ background: isDark ? '#000000' : '#ffffff' }}
+        style={{
+          background: isDark
+            ? '#333333'
+            : 'linear-gradient(135deg, #add8e6, #800080)',
+        }}
         collapsible
       >
         <div
@@ -56,11 +60,27 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         >
           BlueprintFlow
         </div>
-        <Menu theme={isDark ? 'dark' : 'light'} mode="inline" items={items} />
+        <Menu
+          theme={isDark ? 'dark' : 'light'}
+          mode="inline"
+          items={items}
+          style={{
+            background: isDark
+              ? '#333333'
+              : 'linear-gradient(135deg, #add8e6, #800080)',
+          }}
+        />
       </Sider>
       <Layout>
-        <PortalHeader />
-        <Content style={{ margin: 16 }}>
+        <PortalHeader isDark={isDark} />
+        <Content
+          style={{
+            margin: 16,
+            background: isDark
+              ? '#333333'
+              : 'linear-gradient(135deg, #add8e6, #800080)',
+          }}
+        >
           <Routes>
             <Route path="/" element={<Dashboard />} />
             <Route path="/documents" element={<Documents />}>
@@ -74,7 +94,14 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             </Route>
           </Routes>
         </Content>
-        <Footer style={{ textAlign: 'center' }}>
+        <Footer
+          style={{
+            textAlign: 'center',
+            background: isDark
+              ? '#333333'
+              : 'linear-gradient(135deg, #add8e6, #800080)',
+          }}
+        >
 
           <Switch
             checked={isDark}

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -1,4 +1,4 @@
-import { Layout, Button, Space, theme } from 'antd';
+import { Layout, Button, Space } from 'antd';
 import { BellOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
@@ -14,10 +14,13 @@ const breadcrumbs: Record<string, string[]> = {
   '/references': ['Справочники'],
 };
 
-export default function PortalHeader() {
+interface PortalHeaderProps {
+  isDark: boolean;
+}
+
+export default function PortalHeader({ isDark }: PortalHeaderProps) {
   const { pathname } = useLocation();
   const [userEmail, setUserEmail] = useState<string>('');
-  const { token } = theme.useToken();
 
   useEffect(() => {
     if (!supabase) return;
@@ -29,14 +32,14 @@ export default function PortalHeader() {
   return (
     <Header
       style={{
-        background: token.colorBgContainer,
+        background: isDark
+          ? '#333333'
+          : 'linear-gradient(135deg, #add8e6, #800080)',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-
-        color: token.colorText,
-
+        color: isDark ? '#ffffff' : '#000000',
       }}
     >
       <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -36,20 +36,24 @@ const items: MenuProps['items'] = [
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
+  const isDark = true;
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#000000' }} collapsible>
-        <div style={{ color: '#fff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
+      <Sider theme="dark" style={{ background: '#333333' }} collapsible>
+        <div style={{ color: '#ffffff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
           theme="dark"
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}
+          style={{ background: '#333333' }}
         />
       </Sider>
       <Layout>
-        <PortalHeader />
-        <Content style={{ margin: '16px' }}>{children}</Content>
+        <PortalHeader isDark={isDark} />
+        <Content style={{ margin: '16px', background: '#333333', color: '#ffffff' }}>
+          {children}
+        </Content>
       </Layout>
     </Layout>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ export function Root() {
   const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.body.style.backgroundColor = isDark ? '#000000' : '#ffffff'
+    document.body.style.backgroundColor = isDark ? '#333333' : '#ffffff'
     document.body.style.color = isDark ? '#ffffff' : '#000000'
   }, [isDark])
 
@@ -33,15 +33,15 @@ export function Root() {
               algorithm: theme.darkAlgorithm,
               token: {
                 colorPrimary: '#ffffff',
-                colorBgLayout: '#000000',
-                colorBgContainer: '#000000',
+                colorBgLayout: '#333333',
+                colorBgContainer: '#333333',
                 colorText: '#ffffff',
               },
             }
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#000000',
+                colorPrimary: '#800080',
                 colorBgLayout: '#ffffff',
                 colorBgContainer: '#ffffff',
                 colorText: '#000000',


### PR DESCRIPTION
## Summary
- применены новые светлая и тёмная темы с белым фоном и градиентными блоками
- боковое меню и заголовок меняют оформление при переключении темы

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1a3ab2f8832eb77028daa7693f04