### PR TITLE
feat: update portal color themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,28 +47,20 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Sider
-        theme={isDark ? 'dark' : 'light'}
+        theme="dark"
         style={{
-          background: isDark
-            ? '#333333'
-            : 'linear-gradient(135deg, #add8e6, #800080)',
+          background: isDark ? '#555555' : '#0000ff',
         }}
         collapsible
       >
-        <div
-          style={{ color: isDark ? '#ffffff' : '#000000', padding: 16, fontWeight: 600 }}
-        >
+        <div style={{ color: '#ffffff', padding: 16, fontWeight: 600 }}>
           BlueprintFlow
         </div>
         <Menu
-          theme={isDark ? 'dark' : 'light'}
+          theme="dark"
           mode="inline"
           items={items}
-          style={{
-            background: isDark
-              ? '#333333'
-              : 'linear-gradient(135deg, #add8e6, #800080)',
-          }}
+          style={{ background: isDark ? '#555555' : '#0000ff' }}
         />
       </Sider>
       <Layout>
@@ -76,9 +68,8 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Content
           style={{
             margin: 16,
-            background: isDark
-              ? '#333333'
-              : 'linear-gradient(135deg, #add8e6, #800080)',
+            background: isDark ? '#555555' : '#ffffff',
+            color: isDark ? '#ffffff' : '#000000',
           }}
         >
           <Routes>
@@ -97,9 +88,8 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Footer
           style={{
             textAlign: 'center',
-            background: isDark
-              ? '#333333'
-              : 'linear-gradient(135deg, #add8e6, #800080)',
+            background: isDark ? '#555555' : '#0000ff',
+            color: '#ffffff',
           }}
         >
 

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -32,14 +32,12 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
   return (
     <Header
       style={{
-        background: isDark
-          ? '#333333'
-          : 'linear-gradient(135deg, #add8e6, #800080)',
+        background: isDark ? '#555555' : '#0000ff',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        color: isDark ? '#ffffff' : '#000000',
+        color: '#ffffff',
       }}
     >
       <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,17 @@ body {
   background-color: #fff;
   color: #000;
 }
+
+body[data-theme='light'] {
+  --menu-bg: #0000ff;
+}
+
+body[data-theme='dark'] {
+  --menu-bg: #555555;
+}
+
+.ant-menu-dark,
+.ant-menu-dark .ant-menu-sub,
+.ant-menu-dark .ant-menu-submenu-popup {
+  background: var(--menu-bg) !important;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,8 +21,9 @@ export function Root() {
   const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.body.style.backgroundColor = isDark ? '#333333' : '#ffffff'
+    document.body.style.backgroundColor = isDark ? '#555555' : '#ffffff'
     document.body.style.color = isDark ? '#ffffff' : '#000000'
+    document.body.dataset.theme = isDark ? 'dark' : 'light'
   }, [isDark])
 
   return (
@@ -33,15 +34,15 @@ export function Root() {
               algorithm: theme.darkAlgorithm,
               token: {
                 colorPrimary: '#ffffff',
-                colorBgLayout: '#333333',
-                colorBgContainer: '#333333',
+                colorBgLayout: '#555555',
+                colorBgContainer: '#555555',
                 colorText: '#ffffff',
               },
             }
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#800080',
+                colorPrimary: '#0000ff',
                 colorBgLayout: '#ffffff',
                 colorBgContainer: '#ffffff',
                 colorText: '#000000',


### PR DESCRIPTION
## Summary
- apply blue-on-white light theme and gray-on-white dark theme across layout
- ensure menu, header and footer adopt theme colors
- synchronize theme switching with CSS variables for menu popups

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1d41f09c832e8159c8bfe0373f11