### PR TITLE
fix: update light theme colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,20 +47,26 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Sider
-        theme="dark"
+        theme={isDark ? 'dark' : 'light'}
         style={{
-          background: isDark ? '#555555' : '#0000ff',
+          background: isDark ? '#555555' : '#EEF0F1',
         }}
         collapsible
       >
-        <div style={{ color: '#ffffff', padding: 16, fontWeight: 600 }}>
+        <div
+          style={{
+            color: isDark ? '#ffffff' : '#000000',
+            padding: 16,
+            fontWeight: 600,
+          }}
+        >
           BlueprintFlow
         </div>
         <Menu
-          theme="dark"
+          theme={isDark ? 'dark' : 'light'}
           mode="inline"
           items={items}
-          style={{ background: isDark ? '#555555' : '#0000ff' }}
+          style={{ background: isDark ? '#555555' : '#EEF0F1' }}
         />
       </Sider>
       <Layout>
@@ -68,7 +74,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Content
           style={{
             margin: 16,
-            background: isDark ? '#555555' : '#ffffff',
+            background: isDark ? '#555555' : '#EEF0F1',
             color: isDark ? '#ffffff' : '#000000',
           }}
         >
@@ -88,8 +94,8 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Footer
           style={{
             textAlign: 'center',
-            background: isDark ? '#555555' : '#0000ff',
-            color: '#ffffff',
+            background: isDark ? '#555555' : '#EEF0F1',
+            color: isDark ? '#ffffff' : '#000000',
           }}
         >
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,20 +1,32 @@
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  background-color: #fff;
-  color: #000;
 }
 
 body[data-theme='light'] {
-  --menu-bg: #0000ff;
+  --menu-bg: #EEF0F1;
+  --text-color: #000000;
+  background-color: #EEF0F1;
+  color: #000000;
 }
 
 body[data-theme='dark'] {
   --menu-bg: #555555;
+  --text-color: #ffffff;
+  background-color: #555555;
+  color: #ffffff;
 }
 
 .ant-menu-dark,
 .ant-menu-dark .ant-menu-sub,
-.ant-menu-dark .ant-menu-submenu-popup {
+.ant-menu-dark .ant-menu-submenu-popup,
+.ant-menu-light,
+.ant-menu-light .ant-menu-sub,
+.ant-menu-light .ant-menu-submenu-popup {
   background: var(--menu-bg) !important;
+}
+
+.ant-layout-sider-trigger {
+  background: var(--menu-bg) !important;
+  color: var(--text-color) !important;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ export function Root() {
   const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.body.style.backgroundColor = isDark ? '#555555' : '#ffffff'
+    document.body.style.backgroundColor = isDark ? '#555555' : '#EEF0F1'
     document.body.style.color = isDark ? '#ffffff' : '#000000'
     document.body.dataset.theme = isDark ? 'dark' : 'light'
   }, [isDark])
@@ -43,8 +43,8 @@ export function Root() {
               algorithm: theme.defaultAlgorithm,
               token: {
                 colorPrimary: '#0000ff',
-                colorBgLayout: '#ffffff',
-                colorBgContainer: '#ffffff',
+                colorBgLayout: '#EEF0F1',
+                colorBgContainer: '#EEF0F1',
                 colorText: '#000000',
               },
             }


### PR DESCRIPTION
## Summary
- use EEF0F1 as light theme background and menu trigger color
- keep light theme text in black

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c2dcbf0d8832e8f2bb8191d2681a5