### PR TITLE
fix: lighten site background color in light theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Content
           style={{
             margin: 16,
-            background: isDark ? '#555555' : '#EEF0F1',
+            background: isDark ? '#555555' : '#FCFCFC',
             color: isDark ? '#ffffff' : '#000000',
           }}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  background-color: #EEF0F1;
+  background-color: #FCFCFC;
   color: #000;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ export function Root() {
   const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.body.style.backgroundColor = isDark ? '#555555' : '#EEF0F1'
+    document.body.style.backgroundColor = isDark ? '#555555' : '#FCFCFC'
     document.body.style.color = isDark ? '#ffffff' : '#000000'
     document.body.dataset.theme = isDark ? 'dark' : 'light'
   }, [isDark])
@@ -43,8 +43,8 @@ export function Root() {
               algorithm: theme.defaultAlgorithm,
               token: {
                 colorPrimary: '#0000ff',
-                colorBgLayout: '#EEF0F1',
-                colorBgContainer: '#EEF0F1',
+                colorBgLayout: '#FCFCFC',
+                colorBgContainer: '#FCFCFC',
                 colorText: '#000000',
               },
             }


### PR DESCRIPTION
## Summary
- use #FCFCFC for light-theme body and content backgrounds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c3147e588832ebdd73373ed92fcc4