### PR TITLE
fix: закрепление меню и заголовков таблиц

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -52,5 +52,12 @@ export default function DataTable({ table }: DataTableProps) {
     [data],
   );
 
-  return <Table dataSource={data} columns={columns} rowKey={columns[0]?.dataIndex || 'id'} />;
+  return (
+    <Table
+      dataSource={data}
+      columns={columns}
+      rowKey={columns[0]?.dataIndex || 'id'}
+      sticky={{ offsetHeader: 64 }}
+    />
+  );
 }

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -38,6 +38,9 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
         justifyContent: 'space-between',
         alignItems: 'center',
         color: isDark ? '#ffffff' : '#000000',
+        position: 'sticky',
+        top: 0,
+        zIndex: 1000,
       }}
     >
       <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -39,7 +39,11 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const isDark = true;
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#333333' }} collapsible>
+      <Sider
+        theme="dark"
+        style={{ background: '#333333', position: 'sticky', top: 0, height: '100vh', overflow: 'auto' }}
+        collapsible
+      >
         <div style={{ color: '#ffffff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
           theme="dark"
@@ -51,7 +55,9 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       </Sider>
       <Layout>
         <PortalHeader isDark={isDark} />
-        <Content style={{ margin: '16px', background: '#333333', color: '#ffffff' }}>
+        <Content
+          style={{ margin: '16px', background: '#333333', color: '#ffffff' }}
+        >
           {children}
         </Content>
       </Layout>

--- a/src/pages/Smeta.tsx
+++ b/src/pages/Smeta.tsx
@@ -11,12 +11,17 @@ export default function Smeta() {
   const [table, setTable] = useState('estimate');
   return (
     <>
-      <Select
-        options={options}
-        value={table}
-        onChange={setTable}
-        style={{ width: 240, marginBottom: 16 }}
-      />
+      <div
+        style={{
+          position: 'sticky',
+          top: 64,
+          zIndex: 1,
+          background: '#333333',
+          paddingBottom: 16,
+        }}
+      >
+        <Select options={options} value={table} onChange={setTable} style={{ width: 240 }} />
+      </div>
       <DataTable table={table} />
     </>
   );

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -309,7 +309,19 @@ export default function Chessboard() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: 16,
+          position: 'sticky',
+          top: 64,
+          zIndex: 1,
+          background: '#333333',
+          paddingTop: 16,
+          paddingBottom: 16,
+        }}
+      >
         <Space>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <span>Объект</span>
@@ -334,14 +346,36 @@ export default function Chessboard() {
       </div>
       {mode === 'add' && (
         <>
-          <Space style={{ marginBottom: 16 }}>
+          <Space
+            style={{
+              marginBottom: 16,
+              position: 'sticky',
+              top: 64,
+              zIndex: 1,
+              background: '#333333',
+              paddingTop: 16,
+              paddingBottom: 16,
+            }}
+          >
             <Button onClick={handleSave}>Сохранить</Button>
           </Space>
-          <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
+          <Table<RowData>
+            dataSource={rows}
+            columns={columns}
+            pagination={false}
+            rowKey="key"
+            sticky={{ offsetHeader: 64 }}
+          />
         </>
       )}
       {mode === 'show' && (
-        <Table<ViewRow> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
+        <Table<ViewRow>
+          dataSource={viewRows}
+          columns={viewColumns}
+          pagination={false}
+          rowKey="key"
+          sticky={{ offsetHeader: 64 }}
+        />
       )}
     </div>
   )

--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -279,7 +279,19 @@ export default function CostCategories() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: 16,
+          position: 'sticky',
+          top: 64,
+          zIndex: 1,
+          background: '#333333',
+          paddingTop: 16,
+          paddingBottom: 16,
+        }}
+      >
         <Button type="primary" onClick={openAddModal}>
           Добавить
         </Button>
@@ -289,6 +301,7 @@ export default function CostCategories() {
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -345,7 +345,19 @@ export default function Projects() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: 16,
+          position: 'sticky',
+          top: 64,
+          zIndex: 1,
+          background: '#333333',
+          paddingTop: 16,
+          paddingBottom: 16,
+        }}
+      >
         <Button type="primary" onClick={openAddModal}>
           Добавить
         </Button>
@@ -355,6 +367,7 @@ export default function Projects() {
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal

--- a/src/pages/references/Units.tsx
+++ b/src/pages/references/Units.tsx
@@ -157,7 +157,19 @@ export default function Units() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: 16,
+          position: 'sticky',
+          top: 64,
+          zIndex: 1,
+          background: '#333333',
+          paddingTop: 16,
+          paddingBottom: 16,
+        }}
+      >
         <Button type="primary" onClick={openAddModal}>
           Добавить
         </Button>
@@ -167,6 +179,7 @@ export default function Units() {
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal


### PR DESCRIPTION
## Summary
- зафиксированы боковое меню и верхний хедер
- закреплены панели действий и шапки таблиц

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c331651dc832ea439d1a333819d72