### PR TITLE
feat: make layout controls sticky

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -52,5 +52,12 @@ export default function DataTable({ table }: DataTableProps) {
     [data],
   );
 
-  return <Table dataSource={data} columns={columns} rowKey={columns[0]?.dataIndex || 'id'} />;
+  return (
+    <Table
+      dataSource={data}
+      columns={columns}
+      rowKey={columns[0]?.dataIndex || 'id'}
+      sticky={{ offsetHeader: 64 }}
+    />
+  );
 }

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -38,6 +38,9 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
         justifyContent: 'space-between',
         alignItems: 'center',
         color: isDark ? '#ffffff' : '#000000',
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
       }}
     >
       <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+interface TopBarProps {
+  children: ReactNode;
+}
+
+export default function TopBar({ children }: TopBarProps) {
+  return (
+    <div
+      style={{
+        position: 'sticky',
+        top: 64,
+        zIndex: 1,
+        background: '#333333',
+        paddingBottom: 16,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -38,8 +38,12 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const location = useLocation();
   const isDark = true;
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider theme="dark" style={{ background: '#333333' }} collapsible>
+    <Layout style={{ height: '100vh' }}>
+      <Sider
+        theme="dark"
+        style={{ background: '#333333', position: 'sticky', top: 0, height: '100vh', overflow: 'auto' }}
+        collapsible
+      >
         <div style={{ color: '#ffffff', padding: 16, fontWeight: 600 }}>BlueprintFlow</div>
         <Menu
           theme="dark"
@@ -51,7 +55,15 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       </Sider>
       <Layout>
         <PortalHeader isDark={isDark} />
-        <Content style={{ margin: '16px', background: '#333333', color: '#ffffff' }}>
+        <Content
+          style={{
+            margin: '16px',
+            background: '#333333',
+            color: '#ffffff',
+            overflow: 'auto',
+            height: 'calc(100vh - 96px)',
+          }}
+        >
           {children}
         </Content>
       </Layout>

--- a/src/pages/Smeta.tsx
+++ b/src/pages/Smeta.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Select } from 'antd';
 import DataTable from '../components/DataTable';
+import TopBar from '../components/TopBar';
 
 const options = [
   { value: 'estimate', label: 'Шахматка' },
@@ -11,12 +12,9 @@ export default function Smeta() {
   const [table, setTable] = useState('estimate');
   return (
     <>
-      <Select
-        options={options}
-        value={table}
-        onChange={setTable}
-        style={{ width: 240, marginBottom: 16 }}
-      />
+      <TopBar>
+        <Select options={options} value={table} onChange={setTable} style={{ width: 240 }} />
+      </TopBar>
       <DataTable table={table} />
     </>
   );

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -3,6 +3,7 @@ import { App, Button, Input, Select, Space, Table } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { PlusOutlined } from '@ant-design/icons'
 import { supabase } from '../../lib/supabase'
+import TopBar from '../../components/TopBar'
 
 interface RowData {
   key: string
@@ -309,39 +310,55 @@ export default function Chessboard() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
-        <Space>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span>Объект</span>
-            <Select
-              style={{ width: 200 }}
-              value={selectedProject}
-              onChange={setSelectedProject}
-              options={projects.map((p) => ({ value: p.id, label: p.name }))}
-            />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span>Категория затрат</span>
-            <Select
-              style={{ width: 200 }}
-              value={selectedCategory}
-              onChange={setSelectedCategory}
-              options={costCategories.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` }))}
-            />
-          </div>
-        </Space>
-        <Button onClick={handleAddClick}>Добавить</Button>
-      </div>
+      <TopBar>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Space>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <span>Объект</span>
+              <Select
+                style={{ width: 200 }}
+                value={selectedProject}
+                onChange={setSelectedProject}
+                options={projects.map((p) => ({ value: p.id, label: p.name }))}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <span>Категория затрат</span>
+              <Select
+                style={{ width: 200 }}
+                value={selectedCategory}
+                onChange={setSelectedCategory}
+                options={costCategories.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` }))}
+              />
+            </div>
+          </Space>
+          <Button onClick={handleAddClick}>Добавить</Button>
+        </div>
+      </TopBar>
       {mode === 'add' && (
         <>
-          <Space style={{ marginBottom: 16 }}>
-            <Button onClick={handleSave}>Сохранить</Button>
-          </Space>
-          <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
+          <TopBar>
+            <Space>
+              <Button onClick={handleSave}>Сохранить</Button>
+            </Space>
+          </TopBar>
+          <Table<RowData>
+            dataSource={rows}
+            columns={columns}
+            pagination={false}
+            rowKey="key"
+            sticky={{ offsetHeader: 64 }}
+          />
         </>
       )}
       {mode === 'show' && (
-        <Table<ViewRow> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
+        <Table<ViewRow>
+          dataSource={viewRows}
+          columns={viewColumns}
+          pagination={false}
+          rowKey="key"
+          sticky={{ offsetHeader: 64 }}
+        />
       )}
     </div>
   )

--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -13,6 +13,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
+import TopBar from '../../components/TopBar'
 
 interface CostCategory {
   id: string
@@ -279,16 +280,19 @@ export default function CostCategories() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
-        <Button type="primary" onClick={openAddModal}>
-          Добавить
-        </Button>
-      </div>
+      <TopBar>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button type="primary" onClick={openAddModal}>
+            Добавить
+          </Button>
+        </div>
+      </TopBar>
       <Table<CostCategory>
         dataSource={categories ?? []}
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -14,6 +14,7 @@ import type { TableProps } from 'antd'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
+import TopBar from '../../components/TopBar'
 
 interface Project {
   id: string
@@ -345,16 +346,19 @@ export default function Projects() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
-        <Button type="primary" onClick={openAddModal}>
-          Добавить
-        </Button>
-      </div>
+      <TopBar>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button type="primary" onClick={openAddModal}>
+            Добавить
+          </Button>
+        </div>
+      </TopBar>
       <Table<ProjectRow>
         dataSource={projectRows}
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal

--- a/src/pages/references/Units.tsx
+++ b/src/pages/references/Units.tsx
@@ -12,6 +12,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
+import TopBar from '../../components/TopBar'
 
 interface Unit {
   id: string
@@ -157,16 +158,19 @@ export default function Units() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
-        <Button type="primary" onClick={openAddModal}>
-          Добавить
-        </Button>
-      </div>
+      <TopBar>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button type="primary" onClick={openAddModal}>
+            Добавить
+          </Button>
+        </div>
+      </TopBar>
       <Table<Unit>
         dataSource={units ?? []}
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        sticky={{ offsetHeader: 64 }}
       />
 
       <Modal


### PR DESCRIPTION
## Summary
- fix side menu and header to viewport
- keep top action bars visible above tables
- enable sticky table headers across pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c331651dc832ea439d1a333819d72