### PR TITLE
fix: load cost categories from table

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -87,8 +87,9 @@ export default function Chessboard() {
       .select('id, name')
       .then(({ data }) => setUnits((data as UnitOption[]) ?? []))
     supabase
-      .from('cost_categories_sorted')
+      .from('cost_categories')
       .select('code, name')
+      .order('code', { ascending: true })
       .then(({ data }) => setCostCategories((data as CostCategoryOption[]) ?? []))
   }, [])
 


### PR DESCRIPTION
## Summary
- query cost categories from existing table and sort by code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c37d28e20832e919e0dbf3108016f