### PR TITLE
feat: inline editing for locations without units

### DIFF
--- a/src/pages/references/Locations.tsx
+++ b/src/pages/references/Locations.tsx
@@ -2,48 +2,41 @@ import { useMemo, useState } from 'react'
 import {
   App,
   Button,
-  Form,
   Input,
-  Modal,
   Popconfirm,
-  Select,
   Space,
   Table,
 } from 'antd'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
-import { EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
+import {
+  EditOutlined,
+  DeleteOutlined,
+  CheckOutlined,
+  CloseOutlined,
+} from '@ant-design/icons'
 
 interface Location {
-  id: string
+  id: number
   name: string
-  unit_id: string
   created_at: string
-  units: { name: string } | null
+  updated_at: string
 }
 
-interface LocationRow extends Location {
-  unitName: string
-}
-
-interface UnitOption {
-  id: string
-  name: string
-}
+type LocationRow = Location | { id: 'new'; name: string; created_at: string; updated_at: string }
 
 export default function Locations() {
   const { message } = App.useApp()
-  const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
-  const [currentLocation, setCurrentLocation] = useState<LocationRow | null>(null)
-  const [form] = Form.useForm()
+  const [editingId, setEditingId] = useState<number | 'new' | null>(null)
+  const [nameValue, setNameValue] = useState('')
 
   const { data: locations, isLoading, refetch } = useQuery({
-    queryKey: ['locations'],
+    queryKey: ['location'],
     queryFn: async () => {
       if (!supabase) return []
       const { data, error } = await supabase
-        .from('locations')
-        .select('*, units(name)')
+        .from('location')
+        .select('*')
         .order('created_at', { ascending: false })
       if (error) {
         message.error('Не удалось загрузить данные')
@@ -53,101 +46,59 @@ export default function Locations() {
     },
   })
 
-  const { data: units } = useQuery({
-    queryKey: ['units-for-locations'],
-    queryFn: async () => {
-      if (!supabase) return []
-      const { data, error } = await supabase
-        .from('units')
-        .select('id, name')
-        .order('name', { ascending: true })
-      if (error) {
-        message.error('Не удалось загрузить единицы')
-        throw error
-      }
-      return data as UnitOption[]
-    },
-  })
-
-  const locationRows = useMemo<LocationRow[]>(
+  const nameFilters = useMemo(
     () =>
-      (locations ?? []).map((l) => ({
-        ...l,
-        unitName: l.units?.name ?? '',
+      Array.from(new Set((locations ?? []).map((l) => l.name))).map((n) => ({
+        text: n,
+        value: n,
       })),
     [locations],
   )
 
-  const nameFilters = useMemo(
-    () =>
-      Array.from(new Set(locationRows.map((l) => l.name))).map((n) => ({
-        text: n,
-        value: n,
-      })),
-    [locationRows],
-  )
-
-  const unitFilters = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          locationRows
-            .map((l) => l.unitName)
-            .filter((u): u is string => !!u),
-        ),
-      ).map((u) => ({
-        text: u,
-        value: u,
-      })),
-    [locationRows],
-  )
-
-  const openAddModal = () => {
-    form.resetFields()
-    setModalMode('add')
+  const startEdit = (record: Location) => {
+    setEditingId(record.id)
+    setNameValue(record.name)
   }
 
-  const openViewModal = (record: LocationRow) => {
-    setCurrentLocation(record)
-    setModalMode('view')
+  const handleAdd = () => {
+    setEditingId('new')
+    setNameValue('')
   }
 
-  const openEditModal = (record: LocationRow) => {
-    setCurrentLocation(record)
-    form.setFieldsValue({ name: record.name, unit_id: record.unit_id })
-    setModalMode('edit')
+  const cancelEdit = () => {
+    setEditingId(null)
+    setNameValue('')
   }
 
-  const handleSave = async () => {
+  const save = async (id: number | 'new') => {
+    if (!nameValue.trim()) {
+      message.error('Введите название')
+      return
+    }
+    if (!supabase) return
     try {
-      const values = await form.validateFields()
-      if (!supabase) return
-      if (modalMode === 'add') {
-        const { error } = await supabase
-          .from('locations')
-          .insert({ name: values.name, unit_id: values.unit_id })
+      if (id === 'new') {
+        const { error } = await supabase.from('location').insert({ name: nameValue })
         if (error) throw error
         message.success('Запись добавлена')
-      }
-      if (modalMode === 'edit' && currentLocation) {
+      } else {
         const { error } = await supabase
-          .from('locations')
-          .update({ name: values.name, unit_id: values.unit_id })
-          .eq('id', currentLocation.id)
+          .from('location')
+          .update({ name: nameValue })
+          .eq('id', id)
         if (error) throw error
         message.success('Запись обновлена')
       }
-      setModalMode(null)
-      setCurrentLocation(null)
+      cancelEdit()
       await refetch()
     } catch {
       message.error('Не удалось сохранить')
     }
   }
 
-  const handleDelete = async (record: LocationRow) => {
+  const handleDelete = async (record: Location) => {
     if (!supabase) return
-    const { error } = await supabase.from('locations').delete().eq('id', record.id)
+    const { error } = await supabase.from('location').delete().eq('id', record.id)
     if (error) {
       message.error('Не удалось удалить')
     } else {
@@ -163,94 +114,67 @@ export default function Locations() {
       sorter: (a: LocationRow, b: LocationRow) => a.name.localeCompare(b.name),
       filters: nameFilters,
       onFilter: (value: unknown, record: LocationRow) => record.name === value,
-    },
-    {
-      title: 'Единица измерения',
-      dataIndex: 'unitName',
-      sorter: (a: LocationRow, b: LocationRow) => a.unitName.localeCompare(b.unitName),
-      filters: unitFilters,
-      onFilter: (value: unknown, record: LocationRow) => record.unitName === value,
+      render: (_: unknown, record: LocationRow) =>
+        record.id === editingId ? (
+          <Input value={nameValue} onChange={(e) => setNameValue(e.target.value)} />
+        ) : (
+          record.name
+        ),
     },
     {
       title: 'Действия',
       dataIndex: 'actions',
-      render: (_: unknown, record: LocationRow) => (
-        <Space>
-          <Button
-            icon={<EyeOutlined />}
-            onClick={() => openViewModal(record)}
-            aria-label="Просмотр"
-          />
-          <Button
-            icon={<EditOutlined />}
-            onClick={() => openEditModal(record)}
-            aria-label="Редактировать"
-          />
-          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
-            <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
-          </Popconfirm>
-        </Space>
-      ),
+      render: (_: unknown, record: LocationRow) =>
+        record.id === editingId ? (
+          <Space>
+            <Button
+              icon={<CheckOutlined />}
+              onClick={() => save(record.id)}
+              aria-label="Сохранить"
+            />
+            <Button
+              icon={<CloseOutlined />}
+              onClick={cancelEdit}
+              aria-label="Отмена"
+            />
+          </Space>
+        ) : (
+          <Space>
+            {record.id !== 'new' && (
+              <Button
+                icon={<EditOutlined />}
+                onClick={() => startEdit(record as Location)}
+                aria-label="Редактировать"
+              />
+            )}
+            {record.id !== 'new' && (
+              <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record as Location)}>
+                <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
+              </Popconfirm>
+            )}
+          </Space>
+        ),
     },
   ]
+
+  const dataSource: LocationRow[] =
+    editingId === 'new'
+      ? [{ id: 'new', name: nameValue, created_at: '', updated_at: '' }, ...(locations ?? [])]
+      : (locations ?? [])
 
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
-        <Button type="primary" onClick={openAddModal}>
+        <Button type="primary" onClick={handleAdd}>
           Добавить
         </Button>
       </div>
       <Table<LocationRow>
-        dataSource={locationRows}
+        dataSource={dataSource}
         columns={columns}
         rowKey="id"
         loading={isLoading}
       />
-
-      <Modal
-        open={modalMode !== null}
-        title={
-          modalMode === 'add'
-            ? 'Добавить локализацию'
-            : modalMode === 'edit'
-              ? 'Редактировать локализацию'
-              : 'Просмотр локализации'
-        }
-        onCancel={() => {
-          setModalMode(null)
-          setCurrentLocation(null)
-        }}
-        onOk={modalMode === 'view' ? () => setModalMode(null) : handleSave}
-        okText={modalMode === 'view' ? 'Закрыть' : 'Сохранить'}
-        cancelText="Отмена"
-      >
-        {modalMode === 'view' ? (
-          <div>
-            <p>Название: {currentLocation?.name}</p>
-            <p>Единица измерения: {currentLocation?.unitName}</p>
-          </div>
-        ) : (
-          <Form form={form} layout="vertical">
-            <Form.Item
-              label="Название"
-              name="name"
-              rules={[{ required: true, message: 'Введите название' }]}
-            >
-              <Input />
-            </Form.Item>
-            <Form.Item
-              label="Единица измерения"
-              name="unit_id"
-              rules={[{ required: true, message: 'Выберите единицу' }]}
-            >
-              <Select
-                options={(units ?? []).map((u) => ({ label: u.name, value: u.id }))}
-              />
-            </Form.Item>
-          </Form>
-        )}
-      </Modal>
     </div>
   )
 }

--- a/supabase.sql
+++ b/supabase.sql
@@ -96,11 +96,11 @@ create table if not exists units (
 alter table if exists units
 add column if not exists description text;
 
-create table if not exists locations (
-  id uuid primary key default gen_random_uuid(),
+create table if not exists location (
+  id integer primary key generated always as identity,
   name text not null,
-  unit_id uuid references units,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
 );
 
 create table if not exists cost_categories (


### PR DESCRIPTION
## Summary
- remove unit from locations dictionary and enable inline editing directly in table
- drop unit reference from location table schema
- fix API calls to use existing `location` table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c44cdc97c832ea783e93a4be5eb4c