### PR TITLE
feat: add excel import for cost categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "antd": "^5.21.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2147,6 +2148,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2347,6 +2357,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2369,6 +2392,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2417,6 +2449,18 @@
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2858,6 +2902,15 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4226,6 +4279,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -4589,6 +4654,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4618,6 +4701,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "antd": "^5.21.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useRef } from 'react'
 import {
   App,
   Button,
@@ -15,8 +15,10 @@ import {
   CloseOutlined,
   EditOutlined,
   DeleteOutlined,
+  UploadOutlined,
 } from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
+import * as XLSX from 'xlsx'
 import { supabase } from '../../lib/supabase'
 
 interface Category {
@@ -88,6 +90,7 @@ export default function CostCategories() {
     { type: 'category' | 'detail'; key: string; id: number } | null
   >(null)
   const [form] = Form.useForm()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const {
     data: categories,
@@ -168,6 +171,146 @@ export default function CostCategories() {
       return (data ?? []) as LocationOption[]
     },
   })
+
+  const handleImport = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (!supabase) {
+      message.error('Нет подключения к базе данных')
+      return
+    }
+    try {
+      const data = await file.arrayBuffer()
+      const workbook = XLSX.read(data, { type: 'array' })
+      const sheet = workbook.Sheets[workbook.SheetNames[0]]
+      const rows = XLSX.utils.sheet_to_json<(string | number)[]>(sheet, {
+        header: 1,
+      })
+      let imported = 0
+      let skipped = 0
+      let errors = 0
+      for (let i = 1; i < rows.length; i++) {
+        const [num, catName, catUnitName, detName, detUnitName, locName] =
+          rows[i]
+        if (!catName || !detName) {
+          skipped++
+          continue
+        }
+        const catUnit = units?.find((u) => u.name === catUnitName)
+        const detUnit = units?.find((u) => u.name === detUnitName)
+        const location = locations?.find((l) => l.name === locName)
+        if (!catUnit || !detUnit || !location) {
+          errors++
+          continue
+        }
+        let category = categories?.find(
+          (c) => c.number === Number(num) || c.name === catName,
+        )
+        if (category) {
+          if (
+            category.name !== catName ||
+            category.unitName !== catUnit.name ||
+            category.number !== Number(num)
+          ) {
+            const replace = window.confirm(
+              `Категория "${catName}" существует. Заменить?`,
+            )
+            if (replace) {
+              const { error } = await supabase
+                .from('cost_categories')
+                .update({
+                  number: Number(num),
+                  name: catName as string,
+                  unit_id: catUnit.id,
+                })
+                .eq('id', category.id)
+              if (error) {
+                errors++
+                continue
+              }
+            } else {
+              skipped++
+              continue
+            }
+          }
+        } else {
+          const { data: inserted, error } = await supabase
+            .from('cost_categories')
+            .insert({
+              number: Number(num),
+              name: catName as string,
+              unit_id: catUnit.id,
+            })
+            .select('id')
+            .single()
+          if (error || !inserted) {
+            errors++
+            continue
+          }
+          category = {
+            id: inserted.id,
+            number: Number(num),
+            name: catName as string,
+            description: null,
+            unitId: catUnit.id,
+            unitName: catUnit.name,
+          }
+        }
+        const existingDetail = details?.find(
+          (d) =>
+            d.costCategoryId === category.id &&
+            d.name === detName &&
+            d.locationName === location.name,
+        )
+        if (existingDetail) {
+          const replace = window.confirm(
+            `Вид "${detName}" в категории "${catName}" существует. Заменить?`,
+          )
+          if (replace) {
+            const { error } = await supabase
+              .from('detail_cost_categories')
+              .update({
+                unit_id: detUnit.id,
+                location_id: location.id,
+              })
+              .eq('id', existingDetail.id)
+            if (error) {
+              errors++
+            } else {
+              imported++
+            }
+          } else {
+            skipped++
+          }
+        } else {
+          const { error } = await supabase
+            .from('detail_cost_categories')
+            .insert({
+              name: detName as string,
+              unit_id: detUnit.id,
+              cost_category_id: category.id,
+              location_id: location.id,
+            })
+          if (error) {
+            errors++
+          } else {
+            imported++
+          }
+        }
+      }
+      console.log(
+        `Импортировано: ${imported}, пропущено: ${skipped}, ошибок: ${errors}`,
+      )
+      await Promise.all([refetchCategories(), refetchDetails()])
+    } catch (err) {
+      console.error(err)
+      message.error('Ошибка при импорте')
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
 
   const selectedCategoryId = Form.useWatch('costCategoryId', form)
   const selectedCategory = categories?.find((c) => c.id === selectedCategoryId)
@@ -784,6 +927,21 @@ export default function CostCategories() {
 
   return (
     <Form form={form} component={false}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+        <Button
+          icon={<UploadOutlined />}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Импорт
+        </Button>
+        <input
+          type="file"
+          accept=".xlsx,.xls"
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+          onChange={handleImport}
+        />
+      </div>
       <Table<TableRow>
         dataSource={dataSource}
         columns={columns}


### PR DESCRIPTION
## Summary
- add excel import with duplicate handling and logging for cost categories
- add xlsx dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5f9ce290832eb915a8fe833872a1