### PR TITLE
feat: add excel import for cost categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "antd": "^5.21.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2147,6 +2148,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2347,6 +2357,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2369,6 +2392,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2417,6 +2449,18 @@
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2858,6 +2902,15 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4226,6 +4279,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -4589,6 +4654,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4618,6 +4701,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "antd": "^5.21.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
   App,
   Button,
   Form,
   Input,
+  Modal,
   Select,
   Space,
   Table,
@@ -15,7 +16,9 @@ import {
   CloseOutlined,
   EditOutlined,
   DeleteOutlined,
+  UploadOutlined,
 } from '@ant-design/icons'
+import * as XLSX from 'xlsx'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 
@@ -168,6 +171,239 @@ export default function CostCategories() {
       return (data ?? []) as LocationOption[]
     },
   })
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const resolveDuplicate = (
+    title: string,
+  ): Promise<'replace' | 'skip' | 'replaceAll' | 'skipAll'> =>
+    new Promise((resolve) => {
+      const modal = Modal.confirm({
+        title,
+        okText: 'ОК',
+        cancelText: 'ОТМЕНА',
+        onOk: () => resolve('replace'),
+        onCancel: () => resolve('skip'),
+        footer: (_, { OkBtn, CancelBtn }) => (
+          <>
+            <OkBtn />
+            <CancelBtn />
+            <Button
+              onClick={() => {
+                resolve('replaceAll')
+                modal.destroy()
+              }}
+            >
+              ОК для всех
+            </Button>
+            <Button
+              onClick={() => {
+                resolve('skipAll')
+                modal.destroy()
+              }}
+            >
+              ОТМЕНА для всех
+            </Button>
+          </>
+        ),
+      })
+    })
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0]
+    if (!file || !supabase) return
+    let imported = 0
+    let errors = 0
+    let duplicateMode: 'replace' | 'skip' | undefined
+    try {
+      const buffer = await file.arrayBuffer()
+      const workbook = XLSX.read(buffer, { type: 'array' })
+      const sheet = workbook.Sheets[workbook.SheetNames[0]]
+      const data = XLSX.utils.sheet_to_json<(string | number)[]>(sheet, {
+        header: 1,
+      })
+      const unitMap = new Map((units ?? []).map((u) => [u.name, u.id]))
+      const locationMap = new Map(
+        (locations ?? []).map((l) => [l.name, l.id]),
+      )
+      const categoryMap = new Map(
+        (categories ?? []).map((c) => [c.name, c]),
+      )
+      const detailKey = (
+        catId: number,
+        name: string,
+        locId: number | null,
+      ) => `${catId}|${name}|${locId ?? ''}`
+      const detailMap = new Map(
+        (details ?? []).map((d) => [
+          detailKey(d.costCategoryId, d.name, d.locationId),
+          d,
+        ]),
+      )
+      for (let i = 1; i < data.length; i++) {
+        const [num, catNameRaw, catUnitRaw, detNameRaw, detUnitRaw, locRaw] =
+          data[i]
+        const catName = catNameRaw ? String(catNameRaw).trim() : ''
+        if (!catName) {
+          errors++
+          continue
+        }
+        const number =
+          typeof num === 'number' ? num : num ? Number(num) : null
+        const catUnitId =
+          catUnitRaw && String(catUnitRaw).trim()
+            ? unitMap.get(String(catUnitRaw).trim()) ?? null
+            : null
+        let category = categoryMap.get(catName)
+        if (category) {
+          let action = duplicateMode
+          if (!action) {
+            const res = await resolveDuplicate(
+              `Категория "${catName}" уже существует. Заменить?`,
+            )
+            if (res === 'replaceAll') {
+              duplicateMode = 'replace'
+              action = 'replace'
+            } else if (res === 'skipAll') {
+              duplicateMode = 'skip'
+              action = 'skip'
+            } else {
+              action = res
+            }
+          }
+          if (action === 'replace') {
+            const { error } = await supabase
+              .from('cost_categories')
+              .update({ number, unit_id: catUnitId })
+              .eq('id', category.id)
+            if (error) {
+              errors++
+              continue
+            }
+            category = {
+              ...category,
+              number,
+              unitId: catUnitId,
+              unitName:
+                catUnitId
+                  ? units?.find((u) => u.id === catUnitId)?.name ?? null
+                  : null,
+            }
+            categoryMap.set(catName, category)
+          }
+        } else {
+          const { data: inserted, error } = await supabase
+            .from('cost_categories')
+            .insert({ number, name: catName, unit_id: catUnitId })
+            .select('id')
+            .single()
+          if (error || !inserted) {
+            errors++
+            continue
+          }
+          category = {
+            id: inserted.id,
+            number,
+            name: catName,
+            description: null,
+            unitId: catUnitId,
+            unitName:
+              catUnitId
+                ? units?.find((u) => u.id === catUnitId)?.name ?? null
+                : null,
+          }
+          categoryMap.set(catName, category)
+        }
+        const detName = detNameRaw ? String(detNameRaw).trim() : ''
+        if (detName) {
+          const detUnitId =
+            detUnitRaw && String(detUnitRaw).trim()
+              ? unitMap.get(String(detUnitRaw).trim()) ?? null
+              : null
+          const locationId =
+            locRaw && String(locRaw).trim()
+              ? locationMap.get(String(locRaw).trim()) ?? null
+              : null
+          const key = detailKey(category.id, detName, locationId)
+          const existing = detailMap.get(key)
+          if (existing) {
+            let action = duplicateMode
+            if (!action) {
+              const res = await resolveDuplicate(
+                `Вид затрат "${detName}" уже существует. Заменить?`,
+              )
+              if (res === 'replaceAll') {
+                duplicateMode = 'replace'
+                action = 'replace'
+              } else if (res === 'skipAll') {
+                duplicateMode = 'skip'
+                action = 'skip'
+              } else {
+                action = res
+              }
+            }
+            if (action === 'replace') {
+              const { error } = await supabase
+                .from('detail_cost_categories')
+                .update({ unit_id: detUnitId, location_id: locationId })
+                .eq('id', existing.id)
+              if (error) {
+                errors++
+                continue
+              }
+            } else {
+              continue
+            }
+          } else {
+            const { error, data: ins } = await supabase
+              .from('detail_cost_categories')
+              .insert({
+                cost_category_id: category.id,
+                name: detName,
+                unit_id: detUnitId,
+                location_id: locationId,
+              })
+              .select('id')
+              .single()
+            if (error || !ins) {
+              errors++
+              continue
+            }
+            detailMap.set(key, {
+              id: ins.id,
+              name: detName,
+              description: null,
+              unitId: detUnitId,
+              unitName:
+                detUnitId
+                  ? units?.find((u) => u.id === detUnitId)?.name ?? null
+                  : null,
+              costCategoryId: category.id,
+              locationId: locationId ?? 0,
+              locationName:
+                locationId
+                  ? locations?.find((l) => l.id === locationId)?.name ?? null
+                  : null,
+            })
+          }
+        }
+        imported++
+      }
+      console.log(`Импортировано: ${imported}, ошибок: ${errors}`)
+      message.success('Импорт завершен')
+      await Promise.all([refetchCategories(), refetchDetails()])
+    } catch {
+      message.error('Не удалось импортировать')
+    } finally {
+      e.target.value = ''
+    }
+  }
 
   const selectedCategoryId = Form.useWatch('costCategoryId', form)
   const selectedCategory = categories?.find((c) => c.id === selectedCategoryId)
@@ -784,11 +1020,27 @@ export default function CostCategories() {
 
   return (
     <Form form={form} component={false}>
+      <input
+        type="file"
+        accept=".xlsx,.xls"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <Table<TableRow>
         dataSource={dataSource}
         columns={columns}
         rowKey="key"
         loading={loading}
+        title={() => (
+          <Button
+            icon={<UploadOutlined />}
+            onClick={handleImportClick}
+            aria-label="Импорт из Excel"
+          >
+            Импорт
+          </Button>
+        )}
       />
     </Form>
   )


### PR DESCRIPTION
## Summary
- allow importing cost categories and detail categories from Excel with duplicate resolution
- log import results in console
- add xlsx dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c6ba534d0832e974fad80cf51798f