### PR TITLE
feat: add excel import for cost categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "antd": "^5.21.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2147,6 +2148,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2347,6 +2357,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2369,6 +2392,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2417,6 +2449,18 @@
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2858,6 +2902,15 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4226,6 +4279,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -4589,6 +4654,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4618,6 +4701,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "antd": "^5.21.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/sql/unique_cost_categories_name.sql
+++ b/sql/unique_cost_categories_name.sql
@@ -1,0 +1,2 @@
+alter table cost_categories
+  add constraint cost_categories_name_unique unique (name);

--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -8,6 +8,8 @@ import {
   Space,
   Table,
   Popconfirm,
+  Modal,
+  Upload,
 } from 'antd'
 import {
   PlusOutlined,
@@ -15,7 +17,9 @@ import {
   CloseOutlined,
   EditOutlined,
   DeleteOutlined,
+  UploadOutlined,
 } from '@ant-design/icons'
+import * as XLSX from 'xlsx'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 
@@ -169,6 +173,192 @@ export default function CostCategories() {
     },
   })
 
+  type ConflictAction = 'write' | 'skip' | 'writeAll' | 'skipAll'
+
+  const resolveConflict = (title: string): Promise<ConflictAction> =>
+    new Promise((resolve) => {
+      const modal = Modal.confirm({
+        title,
+        okText: 'Записать',
+        cancelText: 'Не записывать',
+        onOk: () => resolve('write'),
+        onCancel: () => resolve('skip'),
+        content: (
+          <Space>
+            <Button
+              onClick={() => {
+                resolve('writeAll')
+                modal.destroy()
+              }}
+            >
+              Записать все
+            </Button>
+            <Button
+              onClick={() => {
+                resolve('skipAll')
+                modal.destroy()
+              }}
+            >
+              Не записывать все
+            </Button>
+          </Space>
+        ),
+      })
+    })
+
+  const handleImport = async (file: File) => {
+    if (!supabase) return false
+    try {
+      const data = await file.arrayBuffer()
+      const workbook = XLSX.read(data, { type: 'array' })
+      const sheet = workbook.Sheets[workbook.SheetNames[0]]
+      const rows = XLSX.utils.sheet_to_json<(string | number)[]>(sheet, {
+        header: 1,
+      })
+      let imported = 0
+      let errors = 0
+      let global: 'writeAll' | 'skipAll' | null = null
+      const categoryMap = new Map<string, number>()
+      ;(categories ?? []).forEach((c) => categoryMap.set(c.name, c.id))
+      const detailMap = new Map<string, number>()
+      ;(details ?? []).forEach((d) =>
+        detailMap.set(`${d.costCategoryId}|${d.name}|${d.locationName ?? ''}`, d.id),
+      )
+
+      for (let i = 1; i < rows.length; i += 1) {
+        const row = rows[i]
+        if (!row) continue
+        const number = row[0] !== undefined && row[0] !== null ? Number(row[0]) : null
+        const categoryName = row[1]?.toString().trim()
+        if (!categoryName) continue
+        const categoryUnitName = row[2]?.toString().trim()
+        const detailName = row[3]?.toString().trim()
+        const detailUnitName = row[4]?.toString().trim()
+        const locationName = row[5]?.toString().trim()
+
+        const categoryUnitId =
+          units?.find((u) => u.name === categoryUnitName)?.id ?? null
+        const detailUnitId =
+          units?.find((u) => u.name === detailUnitName)?.id ?? null
+        const locationId =
+          locations?.find((l) => l.name === locationName)?.id ?? null
+
+        let categoryId = categoryMap.get(categoryName) ?? null
+        if (categoryId) {
+          if (global !== 'writeAll' && global !== 'skipAll') {
+            const res = await resolveConflict(
+              `Категория "${categoryName}" уже существует`,
+            )
+            if (res === 'writeAll') global = 'writeAll'
+            if (res === 'skipAll') global = 'skipAll'
+            if (res === 'write' || res === 'writeAll') {
+              const { error } = await supabase
+                .from('cost_categories')
+                .update({ number, unit_id: categoryUnitId })
+                .eq('id', categoryId)
+              if (error) {
+                errors += 1
+                continue
+              }
+            } else if (res === 'skip' || res === 'skipAll') {
+              continue
+            }
+          } else if (global === 'writeAll') {
+            const { error } = await supabase
+              .from('cost_categories')
+              .update({ number, unit_id: categoryUnitId })
+              .eq('id', categoryId)
+            if (error) {
+              errors += 1
+              continue
+            }
+          } else if (global === 'skipAll') {
+            continue
+          }
+        } else {
+          const { data: inserted, error } = await supabase
+            .from('cost_categories')
+            .insert({ number, name: categoryName, unit_id: categoryUnitId })
+            .select('id')
+            .single()
+          if (error) {
+            errors += 1
+            continue
+          }
+          categoryId = inserted.id
+          categoryMap.set(categoryName, categoryId!)
+        }
+
+        if (detailName) {
+          const key = `${categoryId}|${detailName}|${locationName ?? ''}`
+          const existingDetailId = detailMap.get(key)
+          if (existingDetailId) {
+            if (global !== 'writeAll' && global !== 'skipAll') {
+              const res = await resolveConflict(
+                `Вид затрат "${detailName}" уже существует`,
+              )
+              if (res === 'writeAll') global = 'writeAll'
+              if (res === 'skipAll') global = 'skipAll'
+              if (res === 'write' || res === 'writeAll') {
+                const { error } = await supabase
+                  .from('detail_cost_categories')
+                  .update({
+                    unit_id: detailUnitId,
+                    location_id: locationId,
+                    cost_category_id: categoryId,
+                  })
+                  .eq('id', existingDetailId)
+                if (error) {
+                  errors += 1
+                  continue
+                }
+              } else if (res === 'skip' || res === 'skipAll') {
+                continue
+              }
+            } else if (global === 'writeAll') {
+              const { error } = await supabase
+                .from('detail_cost_categories')
+                .update({
+                  unit_id: detailUnitId,
+                  location_id: locationId,
+                  cost_category_id: categoryId,
+                })
+                .eq('id', existingDetailId)
+              if (error) {
+                errors += 1
+                continue
+              }
+            } else if (global === 'skipAll') {
+              continue
+            }
+          } else {
+            const { data: insertedDetail, error } = await supabase
+              .from('detail_cost_categories')
+              .insert({
+                cost_category_id: categoryId,
+                name: detailName,
+                unit_id: detailUnitId,
+                location_id: locationId,
+              })
+              .select('id')
+              .single()
+            if (error) {
+              errors += 1
+              continue
+            }
+            detailMap.set(key, insertedDetail.id)
+          }
+        }
+        imported += 1
+      }
+      console.log(`Импортировано строк: ${imported}, ошибок: ${errors}`)
+      await Promise.all([refetchCategories(), refetchDetails()])
+    } catch (e) {
+      console.log('Ошибка импорта', e)
+    }
+    return false
+  }
+
   const selectedCategoryId = Form.useWatch('costCategoryId', form)
   const selectedCategory = categories?.find((c) => c.id === selectedCategoryId)
 
@@ -317,6 +507,10 @@ export default function CostCategories() {
       const values = await form.validateFields()
       if (!supabase) return
       if (addMode === 'category') {
+        if (categories?.some((c) => c.name === values.categoryName)) {
+          message.error('Категория уже существует')
+          return
+        }
         const { error } = await supabase.from('cost_categories').insert({
           number: values.number,
           name: values.categoryName,
@@ -349,6 +543,14 @@ export default function CostCategories() {
       const values = await form.validateFields()
       if (!supabase || !editing) return
       if (editing.type === 'category') {
+        if (
+          categories?.some(
+            (c) => c.name === values.categoryName && c.id !== editing.id,
+          )
+        ) {
+          message.error('Категория уже существует')
+          return
+        }
         const { error } = await supabase
           .from('cost_categories')
           .update({
@@ -456,6 +658,13 @@ export default function CostCategories() {
             onClick={() => startAdd('category')}
             aria-label="Добавить категорию"
           />
+          <Upload
+            beforeUpload={handleImport}
+            showUploadList={false}
+            accept=".xlsx,.xls"
+          >
+            <Button icon={<UploadOutlined />} aria-label="Импорт из Excel" />
+          </Upload>
         </Space>
       ),
       dataIndex: 'categoryName',


### PR DESCRIPTION
## Summary
- добавить импорт категорий и видов затрат из Excel с обработкой конфликтов
- предотвратить дубли категорий при сохранении и обновлении
- сделать имя категории затрат уникальным в БД

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c74a4bb34832ebe91a20b5ac819a9