### PR TITLE
feat: enhance chessboard page with filters

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,45 +1,39 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { App, Button, Input, Select, Space, Table } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { PlusOutlined } from '@ant-design/icons'
+import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 
 interface RowData {
   key: string
-  projectId: string
   material: string
   quantityPd: string
   quantitySpec: string
   quantityRd: string
   unitId: string
   costCategoryCode: string
+  costTypeCode: string
+  locationId: string
 }
 
 interface ViewRow {
   key: string
-  project: string
   material: string
   quantityPd: string
   quantitySpec: string
   quantityRd: string
   unit: string
   costCategory: string
+  costType: string
+  location: string
 }
 
-interface ProjectOption {
-  id: string
-  name: string
-}
-
-interface UnitOption {
-  id: string
-  name: string
-}
-
-interface CostCategoryOption {
-  code: string
-  name: string
-}
+interface ProjectOption { id: string; name: string }
+interface UnitOption { id: string; name: string }
+interface CostCategoryOption { code: string; name: string }
+interface CostTypeOption { code: string; name: string; cost_category_code: string }
+interface LocationOption { id: string; name: string }
 
 interface DbRow {
   id: string
@@ -48,227 +42,293 @@ interface DbRow {
   quantitySpec: number | null
   quantityRd: number | null
   unit_id: string | null
-  project_id: string | null
   cost_category_code: string | null
-  projects?: { name: string | null } | null
+  cost_type_code: string | null
+  location_id: string | null
   units?: { name: string | null } | null
+  cost_categories?: { name: string | null } | null
+  detail_cost_categories?: { name: string | null } | null
+  location?: { name: string | null } | null
 }
 
-const emptyRow = (): RowData => ({
+const emptyRow = (defaults: Partial<RowData>): RowData => ({
   key: Math.random().toString(36).slice(2),
-  projectId: '',
   material: '',
   quantityPd: '',
   quantitySpec: '',
   quantityRd: '',
   unitId: '',
-  costCategoryCode: '',
+  costCategoryCode: defaults.costCategoryCode ?? '',
+  costTypeCode: defaults.costTypeCode ?? '',
+  locationId: '',
 })
 
 export default function Chessboard() {
-  const [mode, setMode] = useState<'add' | 'show'>('show')
-  const [rows, setRows] = useState<RowData[]>([])
-  const [viewRows, setViewRows] = useState<ViewRow[]>([])
-  const [projects, setProjects] = useState<ProjectOption[]>([])
-  const [units, setUnits] = useState<UnitOption[]>([])
-  const [costCategories, setCostCategories] = useState<CostCategoryOption[]>([])
-  const [selectedProject, setSelectedProject] = useState<string>()
-  const [selectedCategory, setSelectedCategory] = useState<string>()
   const { message } = App.useApp()
+  const [filters, setFilters] = useState<{ projectId?: string; categoryCode?: string; typeCode?: string }>({})
+  const [appliedFilters, setAppliedFilters] = useState<{ projectId: string; categoryCode?: string; typeCode?: string } | null>(
+    null,
+  )
+  const [mode, setMode] = useState<'view' | 'add'>('view')
+  const [rows, setRows] = useState<RowData[]>([])
 
-  useEffect(() => {
-    if (!supabase) return
-    supabase
-      .from('projects')
-      .select('id, name')
-      .then(({ data }) => setProjects((data as ProjectOption[]) ?? []))
-    supabase
-      .from('units')
-      .select('id, name')
-      .then(({ data }) => setUnits((data as UnitOption[]) ?? []))
-    supabase
-      .from('cost_categories_sorted')
-      .select('code, name')
-      .then(({ data }) => setCostCategories((data as CostCategoryOption[]) ?? []))
-  }, [])
+  const { data: projects } = useQuery<ProjectOption[]>({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase.from('projects').select('id, name').order('name')
+      if (error) throw error
+      return data as ProjectOption[]
+    },
+  })
 
-  const addRow = () => setRows([...rows, emptyRow()])
+  const { data: units } = useQuery<UnitOption[]>({
+    queryKey: ['units'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase.from('units').select('id, name').order('name')
+      if (error) throw error
+      return data as UnitOption[]
+    },
+  })
 
-  const handleChange = (key: string, field: keyof RowData, value: string) => {
+  const { data: costCategories } = useQuery<CostCategoryOption[]>({
+    queryKey: ['costCategories'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase
+        .from('cost_categories')
+        .select('code, name')
+        .order('code')
+      if (error) throw error
+      return data as CostCategoryOption[]
+    },
+  })
+
+  const { data: costTypes } = useQuery<CostTypeOption[]>({
+    queryKey: ['costTypes'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase
+        .from('detail_cost_categories')
+        .select('code, name, cost_category_code')
+      if (error) throw error
+      return data as CostTypeOption[]
+    },
+  })
+
+  const { data: locations } = useQuery<LocationOption[]>({
+    queryKey: ['locations'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase.from('location').select('id, name').order('name')
+      if (error) throw error
+      return data as LocationOption[]
+    },
+  })
+
+  const { data: tableData, refetch } = useQuery<DbRow[]>({
+    queryKey: ['chessboard', appliedFilters],
+    enabled: !!appliedFilters?.projectId,
+    queryFn: async () => {
+      if (!supabase || !appliedFilters) return []
+      const query = supabase
+        .from('chessboard')
+        .select(
+          'id, material, quantityPd, quantitySpec, quantityRd, unit_id, cost_category_code, cost_type_code, location_id, units(name), cost_categories(name), detail_cost_categories(name), location(name)',
+        )
+        .eq('project_id', appliedFilters.projectId)
+      if (appliedFilters.categoryCode) query.eq('cost_category_code', appliedFilters.categoryCode)
+      if (appliedFilters.typeCode) query.eq('cost_type_code', appliedFilters.typeCode)
+      const { data, error } = await query.order('created_at', { ascending: false })
+      if (error) {
+        message.error('Не удалось загрузить данные')
+        throw error
+      }
+      return (data as unknown as DbRow[]) ?? []
+    },
+  })
+
+  const viewRows = useMemo<ViewRow[]>(
+    () =>
+      (tableData ?? []).map((item) => ({
+        key: item.id,
+        material: item.material ?? '',
+        quantityPd: item.quantityPd !== null && item.quantityPd !== undefined ? String(item.quantityPd) : '',
+        quantitySpec: item.quantitySpec !== null && item.quantitySpec !== undefined ? String(item.quantitySpec) : '',
+        quantityRd: item.quantityRd !== null && item.quantityRd !== undefined ? String(item.quantityRd) : '',
+        unit: item.units?.name ?? '',
+        costCategory: item.cost_categories?.name ?? '',
+        costType: item.detail_cost_categories?.name ?? '',
+        location: item.location?.name ?? '',
+      })),
+    [tableData],
+  )
+
+  const handleApply = () => {
+    if (!filters.projectId) {
+      message.warning('Выберите проект')
+      return
+    }
+    setAppliedFilters({ ...filters } as { projectId: string; categoryCode?: string; typeCode?: string })
+    setMode('view')
+  }
+
+  const addRow = () => {
+    if (!appliedFilters) return
+    setRows((prev) => [
+      ...prev,
+      emptyRow({
+        costCategoryCode: appliedFilters.categoryCode ?? '',
+        costTypeCode: appliedFilters.typeCode ?? '',
+      }),
+    ])
+  }
+
+  const handleRowChange = (key: string, field: keyof RowData, value: string) => {
     setRows((prev) => prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)))
   }
 
-  const handleAddClick = () => {
+  const startAdd = () => {
+    if (!appliedFilters) return
+    setRows([
+      emptyRow({
+        costCategoryCode: appliedFilters.categoryCode ?? '',
+        costTypeCode: appliedFilters.typeCode ?? '',
+      }),
+    ])
     setMode('add')
-    setRows([emptyRow()])
   }
-
-  useEffect(() => {
-    if (mode !== 'show' || !supabase || !selectedProject || !selectedCategory) {
-      setViewRows([])
-      return
-    }
-    const load = async () => {
-      if (!supabase) {
-        setViewRows([])
-        return
-      }
-      const { data, error } = await supabase
-        .from('chessboard')
-        .select(
-          'id, material, quantityPd, quantitySpec, quantityRd, unit_id, project_id, cost_category_code, projects(name), units(name)'
-        )
-        .eq('project_id', selectedProject)
-        .eq('cost_category_code', selectedCategory)
-        .limit(100)
-      if (error) {
-        console.error('Error fetching chessboard data:', error)
-        message.error('Не удалось загрузить данные')
-        setViewRows([])
-        return
-      }
-      const rows = (data as unknown as DbRow[] | null) ?? []
-      setViewRows(
-        rows.map((item) => ({
-          key: item.id ? String(item.id) : Math.random().toString(36).slice(2),
-          project: item.projects?.name ?? '',
-          material: item.material ?? '',
-          quantityPd:
-            item.quantityPd !== null && item.quantityPd !== undefined
-              ? String(item.quantityPd)
-              : '',
-          quantitySpec:
-            item.quantitySpec !== null && item.quantitySpec !== undefined
-              ? String(item.quantitySpec)
-              : '',
-          quantityRd:
-            item.quantityRd !== null && item.quantityRd !== undefined
-              ? String(item.quantityRd)
-              : '',
-          unit: item.units?.name ?? '',
-          costCategory: item.cost_category_code ?? '',
-        }))
-      )
-    }
-    void load()
-  }, [mode, selectedProject, selectedCategory, message])
 
   const handleSave = async () => {
-    const tableName = 'chessboard'
-    if (!supabase) {
-      console.error('Supabase client is not configured')
+    if (!supabase || !appliedFilters) return
+    const payload = rows.map((r) => ({
+      project_id: appliedFilters.projectId,
+      material: r.material,
+      quantityPd: r.quantityPd ? Number(r.quantityPd) : null,
+      quantitySpec: r.quantitySpec ? Number(r.quantitySpec) : null,
+      quantityRd: r.quantityRd ? Number(r.quantityRd) : null,
+      unit_id: r.unitId || null,
+      cost_category_code: r.costCategoryCode,
+      cost_type_code: r.costTypeCode || null,
+      location_id: r.locationId || null,
+    }))
+    const { error } = await supabase.from('chessboard').insert(payload)
+    if (error) {
+      message.error(`Не удалось сохранить данные: ${error.message}`)
       return
     }
-    const payload = rows.map(
-      ({ key, projectId, quantityPd, quantitySpec, quantityRd, material, unitId, costCategoryCode }) => {
-        void key
-        return {
-          project_id: projectId || null,
-          material,
-          quantityPd: quantityPd ? Number(quantityPd) : null,
-          quantitySpec: quantitySpec ? Number(quantitySpec) : null,
-          quantityRd: quantityRd ? Number(quantityRd) : null,
-          unit_id: unitId || null,
-          cost_category_code: costCategoryCode || '99',
-        }
-      }
-    )
-    const { error } = await supabase.from(tableName).insert(payload)
-    if (error) {
-      console.error('Error inserting into chessboard:', error)
-      message.error(`Не удалось сохранить данные: ${error.message}`)
-    } else {
-      message.success('Данные успешно сохранены')
-      setMode('show')
-    }
+    message.success('Данные успешно сохранены')
+    setMode('view')
+    setRows([])
+    await refetch()
   }
 
-  const columns = [
+  const columns: ColumnsType<RowData> = [
     {
-      title: 'проект',
-      dataIndex: 'projectId',
-      render: (_: unknown, record: RowData) => (
-        <Select
-          style={{ width: 200 }}
-          value={record.projectId}
-          onChange={(value) => handleChange(record.key, 'projectId', value)}
-          options={projects.map((p) => ({ value: p.id, label: p.name }))}
-        />
-      ),
-    },
-    {
-      title: 'материал',
+      title: 'Материал',
       dataIndex: 'material',
-      width: 400,
-      render: (_: unknown, record: RowData) => (
+      width: 300,
+      render: (_, record) => (
         <Input
-          style={{ width: 400 }}
+          style={{ width: 300 }}
           value={record.material}
-          onChange={(e) => handleChange(record.key, 'material', e.target.value)}
+          onChange={(e) => handleRowChange(record.key, 'material', e.target.value)}
         />
       ),
     },
     {
       title: 'Кол-во по ПД',
       dataIndex: 'quantityPd',
-      render: (_: unknown, record: RowData) => (
+      render: (_, record) => (
         <Input
           style={{ width: '10ch' }}
           value={record.quantityPd}
-          onChange={(e) => handleChange(record.key, 'quantityPd', e.target.value)}
+          onChange={(e) => handleRowChange(record.key, 'quantityPd', e.target.value)}
         />
       ),
     },
     {
       title: 'Кол-во по спеке РД',
       dataIndex: 'quantitySpec',
-      render: (_: unknown, record: RowData) => (
+      render: (_, record) => (
         <Input
           style={{ width: '10ch' }}
           value={record.quantitySpec}
-          onChange={(e) => handleChange(record.key, 'quantitySpec', e.target.value)}
+          onChange={(e) => handleRowChange(record.key, 'quantitySpec', e.target.value)}
         />
       ),
     },
     {
       title: 'Кол-во по пересчету РД',
       dataIndex: 'quantityRd',
-      render: (_: unknown, record: RowData) => (
+      render: (_, record) => (
         <Input
           style={{ width: '10ch' }}
           value={record.quantityRd}
-          onChange={(e) => handleChange(record.key, 'quantityRd', e.target.value)}
+          onChange={(e) => handleRowChange(record.key, 'quantityRd', e.target.value)}
         />
       ),
     },
     {
-      title: 'ед.изм.',
+      title: 'Ед.изм.',
       dataIndex: 'unitId',
-      render: (_: unknown, record: RowData) => (
+      render: (_, record) => (
         <Select
-          style={{ width: 200 }}
+          style={{ width: 160 }}
           value={record.unitId}
-          onChange={(value) => handleChange(record.key, 'unitId', value)}
-          options={units.map((u) => ({ value: u.id, label: u.name }))}
+          onChange={(value) => handleRowChange(record.key, 'unitId', value)}
+          options={units?.map((u) => ({ value: u.id, label: u.name })) ?? []}
         />
       ),
     },
     {
-      title: 'категория затрат',
+      title: 'Категория затрат',
       dataIndex: 'costCategoryCode',
-      render: (_: unknown, record: RowData) => (
+      render: (_, record) => (
         <Select
           style={{ width: 200 }}
           value={record.costCategoryCode}
-          onChange={(value) => handleChange(record.key, 'costCategoryCode', value)}
-          options={costCategories.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` }))}
+          onChange={(value) => {
+            handleRowChange(record.key, 'costCategoryCode', value)
+            handleRowChange(record.key, 'costTypeCode', '')
+          }}
+          options={costCategories?.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` })) ?? []}
+        />
+      ),
+    },
+    {
+      title: 'Вид затрат',
+      dataIndex: 'costTypeCode',
+      render: (_, record) => (
+        <Select
+          style={{ width: 200 }}
+          value={record.costTypeCode}
+          onChange={(value) => handleRowChange(record.key, 'costTypeCode', value)}
+          options={
+            costTypes
+              ?.filter((t) => t.cost_category_code === record.costCategoryCode)
+              .map((t) => ({ value: t.code, label: t.name })) ?? []
+          }
+        />
+      ),
+    },
+    {
+      title: 'Локализация',
+      dataIndex: 'locationId',
+      render: (_, record) => (
+        <Select
+          style={{ width: 200 }}
+          value={record.locationId}
+          onChange={(value) => handleRowChange(record.key, 'locationId', value)}
+          options={locations?.map((l) => ({ value: l.id, label: l.name })) ?? []}
         />
       ),
     },
     {
       title: '',
       dataIndex: 'actions',
-      render: (_: unknown, __: RowData, index: number) =>
+      render: (_, __, index) =>
         index === rows.length - 1 ? (
           <Button type="text" icon={<PlusOutlined />} onClick={addRow} />
         ) : null,
@@ -277,20 +337,18 @@ export default function Chessboard() {
 
   const viewColumns: ColumnsType<ViewRow> = useMemo(() => {
     const base: Array<{ title: string; dataIndex: keyof ViewRow; width?: number }> = [
-      { title: 'проект', dataIndex: 'project' },
-      { title: 'материал', dataIndex: 'material', width: 400 },
+      { title: 'Материал', dataIndex: 'material', width: 300 },
       { title: 'Кол-во по ПД', dataIndex: 'quantityPd' },
       { title: 'Кол-во по спеке РД', dataIndex: 'quantitySpec' },
       { title: 'Кол-во по пересчету РД', dataIndex: 'quantityRd' },
-      { title: 'ед.изм.', dataIndex: 'unit' },
-      { title: 'категория затрат', dataIndex: 'costCategory' },
+      { title: 'Ед.изм.', dataIndex: 'unit' },
+      { title: 'Категория затрат', dataIndex: 'costCategory' },
+      { title: 'Вид затрат', dataIndex: 'costType' },
+      { title: 'Локализация', dataIndex: 'location' },
     ]
 
     return base.map((col) => {
-      const values = Array.from(
-        new Set(viewRows.map((row) => row[col.dataIndex]).filter((v) => v !== undefined && v !== '')),
-      )
-
+      const values = Array.from(new Set(viewRows.map((row) => row[col.dataIndex]).filter((v) => v)))
       return {
         ...col,
         sorter: (a: ViewRow, b: ViewRow) => {
@@ -309,30 +367,39 @@ export default function Chessboard() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
-        <Space>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span>Объект</span>
-            <Select
-              style={{ width: 200 }}
-              value={selectedProject}
-              onChange={setSelectedProject}
-              options={projects.map((p) => ({ value: p.id, label: p.name }))}
-            />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span>Категория затрат</span>
-            <Select
-              style={{ width: 200 }}
-              value={selectedCategory}
-              onChange={setSelectedCategory}
-              options={costCategories.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` }))}
-            />
-          </div>
-        </Space>
-        <Button onClick={handleAddClick}>Добавить</Button>
-      </div>
-      {mode === 'add' && (
+      <Space style={{ marginBottom: 16 }}>
+        <Select
+          placeholder="Проект"
+          style={{ width: 200 }}
+          value={filters.projectId}
+          onChange={(value) => setFilters((f) => ({ ...f, projectId: value }))}
+          options={projects?.map((p) => ({ value: p.id, label: p.name })) ?? []}
+        />
+        <Select
+          placeholder="Категория затрат"
+          style={{ width: 200 }}
+          value={filters.categoryCode}
+          onChange={(value) => setFilters((f) => ({ ...f, categoryCode: value, typeCode: undefined }))}
+          options={costCategories?.map((c) => ({ value: c.code, label: `${c.code} ${c.name}` })) ?? []}
+        />
+        <Select
+          placeholder="Вид затрат"
+          style={{ width: 200 }}
+          value={filters.typeCode}
+          onChange={(value) => setFilters((f) => ({ ...f, typeCode: value }))}
+          options={
+            costTypes
+              ?.filter((t) => t.cost_category_code === filters.categoryCode)
+              .map((t) => ({ value: t.code, label: t.name })) ?? []
+          }
+          disabled={!filters.categoryCode}
+        />
+        <Button type="primary" onClick={handleApply} disabled={!filters.projectId}>
+          Применить
+        </Button>
+        {appliedFilters && mode === 'view' && <Button onClick={startAdd}>Добавить</Button>}
+      </Space>
+      {appliedFilters && mode === 'add' && (
         <>
           <Space style={{ marginBottom: 16 }}>
             <Button onClick={handleSave}>Сохранить</Button>
@@ -340,9 +407,10 @@ export default function Chessboard() {
           <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
         </>
       )}
-      {mode === 'show' && (
+      {appliedFilters && mode === 'view' && (
         <Table<ViewRow> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
       )}
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- redesign chessboard page with project, cost category and cost type filters
- add editing table with unit, cost type and localization fields
- load cost categories and types from reference tables

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c92a9a7c4832ea1f5242130b3e2e5