### PR TITLE
fix: apply all chessboard filters

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -134,10 +134,12 @@ export default function Chessboard() {
     enabled: !!appliedFilters?.projectId,
     queryFn: async () => {
       if (!supabase || !appliedFilters) return []
+      const relation =
+        appliedFilters.categoryId || appliedFilters.typeId ? 'chessboard_mapping!inner' : 'chessboard_mapping'
       const query = supabase
         .from('chessboard')
         .select(
-          'id, material, quantityPd, quantitySpec, quantityRd, unit_id, units(name), chessboard_mapping(cost_category_id, cost_type_id, location_id, cost_categories(name), detail_cost_categories(name), location(name))',
+          `id, material, quantityPd, quantitySpec, quantityRd, unit_id, units(name), ${relation}(cost_category_id, cost_type_id, location_id, cost_categories(name), detail_cost_categories(name), location(name))`,
         )
         .eq('project_id', appliedFilters.projectId)
       if (appliedFilters.categoryId)


### PR DESCRIPTION
## Summary
- ensure chessboard query filters by category and type when applied

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca7cc7f30832e8a1d670b8f99e5cd