### PR TITLE
feat: add floor bounds per block

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -449,20 +449,6 @@
   },
   {
     "table_name": "projects",
-    "column_name": "bottom_underground_floor",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "top_ground_floor",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
     "column_name": "updated_at",
     "data_type": "timestamp with time zone",
     "is_nullable": "NO",

--- a/supabase.sql
+++ b/supabase.sql
@@ -3,8 +3,6 @@ create table if not exists projects (
   name text not null,
   description text,
   address text,
-  bottom_underground_floor integer,
-  top_ground_floor integer,
   blocks_count integer,
   created_at timestamptz default now()
 );
@@ -19,7 +17,11 @@ on conflict do nothing;
 
 create table if not exists blocks (
   id uuid primary key default gen_random_uuid(),
-  name text not null
+  name text not null,
+  bottom_underground_floor integer,
+  top_ground_floor integer,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
 );
 
 create table if not exists projects_blocks (


### PR DESCRIPTION
## Summary
- track min and max floors per block instead of per project
- adjust projects reference UI to manage block floor ranges
- update schema to store floor ranges in blocks table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca9b4b930832ea1f0f136a9ae6ff3