### PR TITLE
fix: use semicolon separator for block floor range

### DIFF
--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -288,7 +288,7 @@ export default function Projects() {
         record.blocks
           .map(
             (b) =>
-              `${b.name} (${b.bottom_underground_floor ?? ''}–${b.top_ground_floor ?? ''})`,
+              `${b.name} (${b.bottom_underground_floor ?? ''}; ${b.top_ground_floor ?? ''})`,
           )
           .join('; '),
     },


### PR DESCRIPTION
## Summary
- replace dash with semicolon between block floor values in Projects reference table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cad75c9c0832ea68cccdb4c102b3f