### PR TITLE
fix: reset filters when project changes

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -499,7 +499,7 @@ export default function Chessboard() {
           placeholder="Проект"
           style={{ width: 200 }}
           value={filters.projectId}
-          onChange={(value) => setFilters((f) => ({ ...f, projectId: value }))}
+          onChange={(value) => setFilters({ projectId: value })}
           options={projects?.map((p) => ({ value: p.id, label: p.name })) ?? []}
         />
         <Select


### PR DESCRIPTION
## Summary
- reset cost category and type filters when switching projects on chessboard page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cbf966f2c832e817caa302eadc5ee