### PR TITLE
feat: show page title in header

### DIFF
--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -3,16 +3,9 @@ import { BellOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
+import { portalConfig, pageTitles } from '../lib/portalConfig';
 
 const { Header } = Layout;
-
-const breadcrumbs: Record<string, string[]> = {
-  '/': ['Dashboard'],
-  '/documents': ['Документы'],
-  '/documents/chessboard': ['Документы', 'Шахматка'],
-  '/documents/vor': ['Документы', 'ВОР'],
-  '/references': ['Справочники'],
-};
 
 interface PortalHeaderProps {
   isDark: boolean;
@@ -21,6 +14,7 @@ interface PortalHeaderProps {
 export default function PortalHeader({ isDark }: PortalHeaderProps) {
   const { pathname } = useLocation();
   const [userEmail, setUserEmail] = useState<string>('');
+  const title = portalConfig.header.showPageTitle ? pageTitles[pathname] ?? '' : '';
 
   useEffect(() => {
     if (!supabase) return;
@@ -40,7 +34,7 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
         color: isDark ? '#ffffff' : '#000000',
       }}
     >
-      <span>{breadcrumbs[pathname]?.join(' / ') || ''}</span>
+      {portalConfig.header.showPageTitle && <span>{title}</span>}
       <Space size="middle">
         <Button type="text" icon={<BellOutlined />} />
         <Space>

--- a/src/lib/portalConfig.ts
+++ b/src/lib/portalConfig.ts
@@ -1,0 +1,25 @@
+export const portalConfig = {
+  header: {
+    showPageTitle: true,
+  },
+};
+
+export const pageTitles: Record<string, string> = {
+  '/': 'Dashboard',
+  '/documents': 'Документы',
+  '/documents/chessboard': 'Шахматка',
+  '/documents/vor': 'ВОР',
+  '/documents/estimate': 'Шахматка',
+  '/documents/estimate-monolith': 'Шахматка монолит',
+  '/documents/work-volume': 'ВОР для подрядчиков',
+  '/documents/cost': 'Смета',
+  '/library/docs': 'Документация',
+  '/library/rd-codes': 'Шифры РД',
+  '/library/pd-codes': 'Шифры ПД',
+  '/references': 'Справочники',
+  '/references/cost-categories': 'Категории затрат',
+  '/references/projects': 'Проекты',
+  '/references/locations': 'Локализации',
+  '/reports': 'Отчёты',
+  '/admin': 'Администрирование',
+};


### PR DESCRIPTION
## Summary
- display current page title on the left side of header
- add portal settings with page title mapping

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc1d24524832eaba6d028b847a6b6