### PR TITLE
fix: remove Popconfirm cleanup warnings

### DIFF
--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -7,7 +7,6 @@ import {
   Select,
   Space,
   Table,
-  Popconfirm,
   Upload,
   Modal,
 } from 'antd'
@@ -904,14 +903,18 @@ export default function CostCategories() {
               onClick={() => startEdit(record)}
               aria-label="Редактировать"
             />
-            <Popconfirm
-              title="Удалить?"
-              onConfirm={() => handleDelete(record)}
-              okText="Да"
-              cancelText="Нет"
-            >
-              <Button icon={<DeleteOutlined />} aria-label="Удалить" />
-            </Popconfirm>
+            <Button
+              icon={<DeleteOutlined />}
+              aria-label="Удалить"
+              onClick={() =>
+                Modal.confirm({
+                  title: 'Удалить?',
+                  okText: 'Да',
+                  cancelText: 'Нет',
+                  onOk: () => handleDelete(record),
+                })
+              }
+            />
           </Space>
         )
       },

--- a/src/pages/references/Units.tsx
+++ b/src/pages/references/Units.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   Input,
   Modal,
-  Popconfirm,
   Space,
   Table,
 } from 'antd'
@@ -147,9 +146,19 @@ export default function Units() {
             onClick={() => openEditModal(record)}
             aria-label="Редактировать"
           />
-          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
-            <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
-          </Popconfirm>
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            aria-label="Удалить"
+            onClick={() =>
+              Modal.confirm({
+                title: 'Удалить запись?',
+                okText: 'Да',
+                cancelText: 'Нет',
+                onOk: () => handleDelete(record),
+              })
+            }
+          />
         </Space>
       ),
     },


### PR DESCRIPTION
## Summary
- use `Modal.confirm` instead of `Popconfirm` in cost categories
- replace `Popconfirm` with `Modal.confirm` in units table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc93d59ec832e924be8f4f29978f7