### PR TITLE
fix: remove Popconfirm cleanup warnings

### DIFF
--- a/src/pages/references/CostCategories.tsx
+++ b/src/pages/references/CostCategories.tsx
@@ -7,9 +7,7 @@ import {
   Select,
   Space,
   Table,
-  Popconfirm,
   Upload,
-  Modal,
 } from 'antd'
 import {
   PlusOutlined,
@@ -86,7 +84,7 @@ interface DetailCategoryRowDB {
 }
 
 export default function CostCategories() {
-  const { message } = App.useApp()
+  const { message, modal } = App.useApp()
   const [addMode, setAddMode] = useState<'category' | 'detail' | null>(null)
   const [editing, setEditing] = useState<
     { type: 'category' | 'detail'; key: string; id: number } | null
@@ -353,7 +351,7 @@ export default function CostCategories() {
 
         if (existingDetail) {
           const replace = await new Promise<boolean>((resolve) => {
-            Modal.confirm({
+            modal.confirm({
               title: 'Дубликат',
               content: `Вид затрат "${detailName}" уже существует. Заменить?`,
               okText: 'Заменить',
@@ -904,14 +902,18 @@ export default function CostCategories() {
               onClick={() => startEdit(record)}
               aria-label="Редактировать"
             />
-            <Popconfirm
-              title="Удалить?"
-              onConfirm={() => handleDelete(record)}
-              okText="Да"
-              cancelText="Нет"
-            >
-              <Button icon={<DeleteOutlined />} aria-label="Удалить" />
-            </Popconfirm>
+            <Button
+              icon={<DeleteOutlined />}
+              aria-label="Удалить"
+              onClick={() =>
+                modal.confirm({
+                  title: 'Удалить?',
+                  okText: 'Да',
+                  cancelText: 'Нет',
+                  onOk: () => handleDelete(record),
+                })
+              }
+            />
           </Space>
         )
       },

--- a/src/pages/references/Units.tsx
+++ b/src/pages/references/Units.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   Input,
   Modal,
-  Popconfirm,
   Space,
   Table,
 } from 'antd'
@@ -21,7 +20,7 @@ interface Unit {
 }
 
 export default function Units() {
-  const { message } = App.useApp()
+  const { message, modal } = App.useApp()
   const [modalMode, setModalMode] = useState<'add' | 'edit' | 'view' | null>(null)
   const [currentUnit, setCurrentUnit] = useState<Unit | null>(null)
   const [form] = Form.useForm()
@@ -147,9 +146,19 @@ export default function Units() {
             onClick={() => openEditModal(record)}
             aria-label="Редактировать"
           />
-          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
-            <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
-          </Popconfirm>
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            aria-label="Удалить"
+            onClick={() =>
+              modal.confirm({
+                title: 'Удалить запись?',
+                okText: 'Да',
+                cancelText: 'Нет',
+                onOk: () => handleDelete(record),
+              })
+            }
+          />
         </Space>
       ),
     },


### PR DESCRIPTION
## Summary
- use `App`'s `modal.confirm` in cost categories and units instead of static Modal API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc93d59ec832e924be8f4f29978f7