### PR TITLE
fix: memoize reference table columns to prevent AntD cleanup warning

### DIFF
--- a/src/pages/references/Locations.tsx
+++ b/src/pages/references/Locations.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   App,
   Button,
@@ -6,6 +6,7 @@ import {
   Popconfirm,
   Space,
   Table,
+  type TableProps,
 } from 'antd'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
@@ -55,59 +56,66 @@ export default function Locations() {
     [locations],
   )
 
-  const startEdit = (record: Location) => {
+  const startEdit = useCallback((record: Location) => {
     setEditingId(record.id)
     setNameValue(record.name)
-  }
+  }, [])
 
-  const handleAdd = () => {
+  const handleAdd = useCallback(() => {
     setEditingId('new')
     setNameValue('')
-  }
+  }, [])
 
-  const cancelEdit = () => {
+  const cancelEdit = useCallback(() => {
     setEditingId(null)
     setNameValue('')
-  }
+  }, [])
 
-  const save = async (id: number | 'new') => {
-    if (!nameValue.trim()) {
-      message.error('Введите название')
-      return
-    }
-    if (!supabase) return
-    try {
-      if (id === 'new') {
-        const { error } = await supabase.from('location').insert({ name: nameValue })
-        if (error) throw error
-        message.success('Запись добавлена')
-      } else {
-        const { error } = await supabase
-          .from('location')
-          .update({ name: nameValue })
-          .eq('id', id)
-        if (error) throw error
-        message.success('Запись обновлена')
+  const save = useCallback(
+    async (id: number | 'new') => {
+      if (!nameValue.trim()) {
+        message.error('Введите название')
+        return
       }
-      cancelEdit()
-      await refetch()
-    } catch {
-      message.error('Не удалось сохранить')
-    }
-  }
+      if (!supabase) return
+      try {
+        if (id === 'new') {
+          const { error } = await supabase.from('location').insert({ name: nameValue })
+          if (error) throw error
+          message.success('Запись добавлена')
+        } else {
+          const { error } = await supabase
+            .from('location')
+            .update({ name: nameValue })
+            .eq('id', id)
+          if (error) throw error
+          message.success('Запись обновлена')
+        }
+        cancelEdit()
+        await refetch()
+      } catch {
+        message.error('Не удалось сохранить')
+      }
+    },
+    [nameValue, message, cancelEdit, refetch],
+  )
 
-  const handleDelete = async (record: Location) => {
-    if (!supabase) return
-    const { error } = await supabase.from('location').delete().eq('id', record.id)
-    if (error) {
-      message.error('Не удалось удалить')
-    } else {
-      message.success('Запись удалена')
-      refetch()
-    }
-  }
+  const handleDelete = useCallback(
+    async (record: Location) => {
+      if (!supabase) return
+      const { error } = await supabase.from('location').delete().eq('id', record.id)
+      if (error) {
+        message.error('Не удалось удалить')
+      } else {
+        message.success('Запись удалена')
+        refetch()
+      }
+    },
+    [message, refetch],
+  )
 
-  const columns = [
+  const columns: TableProps<LocationRow>['columns'] = useMemo(
+    () => [
     {
       title: 'Название',
       dataIndex: 'name',
@@ -155,12 +163,17 @@ export default function Locations() {
           </Space>
         ),
     },
-  ]
+  ],
+    [editingId, nameValue, nameFilters, startEdit, cancelEdit, save, handleDelete],
+  )
 
-  const dataSource: LocationRow[] =
-    editingId === 'new'
-      ? [{ id: 'new', name: nameValue, created_at: '', updated_at: '' }, ...(locations ?? [])]
-      : (locations ?? [])
+  const dataSource = useMemo<LocationRow[]>(
+    () =>
+      editingId === 'new'
+        ? [{ id: 'new', name: nameValue, created_at: '', updated_at: '' }, ...(locations ?? [])]
+        : (locations ?? []),
+    [editingId, locations, nameValue],
+  )
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- memoize editing handlers and column definitions in Locations reference table
- memoize action handlers and columns for Projects reference table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd01e006c832e9493e52a6f3310ff