### PR TITLE
fix: memoize reference table columns and remove popconfirm warning

### DIFF
--- a/src/pages/references/Locations.tsx
+++ b/src/pages/references/Locations.tsx
@@ -1,11 +1,12 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   App,
   Button,
   Input,
-  Popconfirm,
+  Modal,
   Space,
   Table,
+  type TableProps,
 } from 'antd'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
@@ -55,59 +56,79 @@ export default function Locations() {
     [locations],
   )
 
-  const startEdit = (record: Location) => {
+  const startEdit = useCallback((record: Location) => {
     setEditingId(record.id)
     setNameValue(record.name)
-  }
+  }, [])
 
-  const handleAdd = () => {
+  const handleAdd = useCallback(() => {
     setEditingId('new')
     setNameValue('')
-  }
+  }, [])
 
-  const cancelEdit = () => {
+  const cancelEdit = useCallback(() => {
     setEditingId(null)
     setNameValue('')
-  }
+  }, [])
 
-  const save = async (id: number | 'new') => {
-    if (!nameValue.trim()) {
-      message.error('Введите название')
-      return
-    }
-    if (!supabase) return
-    try {
-      if (id === 'new') {
-        const { error } = await supabase.from('location').insert({ name: nameValue })
-        if (error) throw error
-        message.success('Запись добавлена')
-      } else {
-        const { error } = await supabase
-          .from('location')
-          .update({ name: nameValue })
-          .eq('id', id)
-        if (error) throw error
-        message.success('Запись обновлена')
+  const save = useCallback(
+    async (id: number | 'new') => {
+      if (!nameValue.trim()) {
+        message.error('Введите название')
+        return
       }
-      cancelEdit()
-      await refetch()
-    } catch {
-      message.error('Не удалось сохранить')
-    }
-  }
+      if (!supabase) return
+      try {
+        if (id === 'new') {
+          const { error } = await supabase.from('location').insert({ name: nameValue })
+          if (error) throw error
+          message.success('Запись добавлена')
+        } else {
+          const { error } = await supabase
+            .from('location')
+            .update({ name: nameValue })
+            .eq('id', id)
+          if (error) throw error
+          message.success('Запись обновлена')
+        }
+        cancelEdit()
+        await refetch()
+      } catch {
+        message.error('Не удалось сохранить')
+      }
+    },
+    [nameValue, message, cancelEdit, refetch],
+  )
 
-  const handleDelete = async (record: Location) => {
-    if (!supabase) return
-    const { error } = await supabase.from('location').delete().eq('id', record.id)
-    if (error) {
-      message.error('Не удалось удалить')
-    } else {
-      message.success('Запись удалена')
-      refetch()
-    }
-  }
+  const handleDelete = useCallback(
+    async (record: Location) => {
+      if (!supabase) return
+      const { error } = await supabase.from('location').delete().eq('id', record.id)
+      if (error) {
+        message.error('Не удалось удалить')
+      } else {
+        message.success('Запись удалена')
+        refetch()
+      }
+    },
+    [message, refetch],
+  )
 
-  const columns = [
+  const confirmDelete = useCallback(
+    (record: Location) => {
+      Modal.confirm({
+        title: 'Удалить запись?',
+        okText: 'Удалить',
+        okButtonProps: { danger: true },
+        cancelText: 'Отмена',
+        onOk: () => handleDelete(record),
+      })
+    },
+    [handleDelete],
+  )
+
+  const columns: TableProps<LocationRow>['columns'] = useMemo(
+    () => [
     {
       title: 'Название',
       dataIndex: 'name',
@@ -148,19 +169,27 @@ export default function Locations() {
               />
             )}
             {record.id !== 'new' && (
-              <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record as Location)}>
-                <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
-              </Popconfirm>
+              <Button
+                danger
+                icon={<DeleteOutlined />}
+                onClick={() => confirmDelete(record as Location)}
+                aria-label="Удалить"
+              />
             )}
           </Space>
         ),
     },
-  ]
+  ],
+    [editingId, nameValue, nameFilters, startEdit, cancelEdit, save, confirmDelete],
+  )
 
-  const dataSource: LocationRow[] =
-    editingId === 'new'
-      ? [{ id: 'new', name: nameValue, created_at: '', updated_at: '' }, ...(locations ?? [])]
-      : (locations ?? [])
+  const dataSource = useMemo<LocationRow[]>(
+    () =>
+      editingId === 'new'
+        ? [{ id: 'new', name: nameValue, created_at: '', updated_at: '' }, ...(locations ?? [])]
+        : (locations ?? []),
+    [editingId, locations, nameValue],
+  )
 
   return (
     <div>

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   App,
   Button,
@@ -77,32 +77,35 @@ export default function Projects() {
     [projects],
   )
 
-  const openAddModal = () => {
+  const openAddModal = useCallback(() => {
     form.resetFields()
     setBlocksCount(0)
     setExistingBlockIds([])
     setModalMode('add')
-  }
+  }, [form])
 
-  const openViewModal = (record: ProjectRow) => {
+  const openViewModal = useCallback((record: ProjectRow) => {
     setCurrentProject(record)
     setModalMode('view')
-  }
+  }, [])
 
-  const openEditModal = (record: ProjectRow) => {
-    setCurrentProject(record)
-    const blocks = record.blocks
-    const blockIds = record.projects_blocks?.map((b) => b.block_id) ?? []
-    setExistingBlockIds(blockIds)
-    setBlocksCount(blocks.length)
-    form.setFieldsValue({
-      name: record.name,
-      address: record.address,
-      blocks_count: blocks.length || record.blocks_count,
-      blocks,
-    })
-    setModalMode('edit')
-  }
+  const openEditModal = useCallback(
+    (record: ProjectRow) => {
+      setCurrentProject(record)
+      const blocks = record.blocks
+      const blockIds = record.projects_blocks?.map((b) => b.block_id) ?? []
+      setExistingBlockIds(blockIds)
+      setBlocksCount(blocks.length)
+      form.setFieldsValue({
+        name: record.name,
+        address: record.address,
+        blocks_count: blocks.length || record.blocks_count,
+        blocks,
+      })
+      setModalMode('edit')
+    },
+    [form],
+  )
 
   const handleBlocksCountChange = (value: number | null) => {
     const count = value ?? 0
@@ -191,25 +194,28 @@ export default function Projects() {
     }
   }
 
-  const handleDelete = async (record: ProjectRow) => {
-    if (!supabase) return
-    const { data } = await supabase
-      .from('projects_blocks')
-      .select('block_id')
-      .eq('project_id', record.id)
-    const idsData = data as { block_id: string }[] | null
-    const blockIds = idsData?.map((b) => b.block_id) ?? []
-    const { error } = await supabase.from('projects').delete().eq('id', record.id)
-    if (error) {
-      message.error('Не удалось удалить')
-    } else {
-      if (blockIds.length) {
-        await supabase.from('blocks').delete().in('id', blockIds)
+  const handleDelete = useCallback(
+    async (record: ProjectRow) => {
+      if (!supabase) return
+      const { data } = await supabase
+        .from('projects_blocks')
+        .select('block_id')
+        .eq('project_id', record.id)
+      const idsData = data as { block_id: string }[] | null
+      const blockIds = idsData?.map((b) => b.block_id) ?? []
+      const { error } = await supabase.from('projects').delete().eq('id', record.id)
+      if (error) {
+        message.error('Не удалось удалить')
+      } else {
+        if (blockIds.length) {
+          await supabase.from('blocks').delete().in('id', blockIds)
+        }
+        message.success('Проект удалён')
+        refetch()
       }
-      message.success('Проект удалён')
-      refetch()
-    }
-  }
+    },
+    [message, refetch],
+  )
 
   const nameFilters = useMemo(
     () =>
@@ -237,7 +243,7 @@ export default function Projects() {
         new Set(
           (projects ?? [])
             .map((p) => p.blocks_count)
-            .filter((n): n is number => n !== null),
+            .filter((n): n is number => typeof n === 'number'),
         ),
       ).map((n) => ({ text: n.toString(), value: n })),
     [projects],
@@ -252,68 +258,79 @@ export default function Projects() {
     [projectRows],
   )
 
-  const columns: TableProps<ProjectRow>['columns'] = [
-    {
-      title: 'Название',
-      dataIndex: 'name',
-      sorter: (a: ProjectRow, b: ProjectRow) => a.name.localeCompare(b.name),
-      filters: nameFilters,
-      onFilter: (value: unknown, record: ProjectRow) => record.name === value,
-    },
-    {
-      title: 'Адрес',
-      dataIndex: 'address',
-      sorter: (a: ProjectRow, b: ProjectRow) =>
-        (a.address ?? '').localeCompare(b.address ?? ''),
-      filters: addressFilters,
-      onFilter: (value: unknown, record: ProjectRow) => record.address === value,
-    },
-    {
-      title: 'Кол-во корпусов',
-      dataIndex: 'blocks_count',
-      sorter: (a: ProjectRow, b: ProjectRow) =>
-        (a.blocks_count ?? 0) - (b.blocks_count ?? 0),
-      filters: blockCountFilters,
-      onFilter: (value: unknown, record: ProjectRow) => record.blocks_count === value,
-    },
-    {
-      title: 'Корпуса',
-      dataIndex: 'blockNames',
-      sorter: (a: ProjectRow, b: ProjectRow) =>
-        a.blockNames.join(';').localeCompare(b.blockNames.join(';')),
-      filters: blockNameFilters,
-      onFilter: (value: unknown, record: ProjectRow) =>
-        record.blockNames.includes(value as string),
-      render: (_: unknown, record: ProjectRow) =>
-        record.blocks
-          .map(
-            (b) =>
-              `${b.name} (${b.bottom_underground_floor ?? ''}; ${b.top_ground_floor ?? ''})`,
-          )
-          .join('; '),
-    },
-    {
-      title: 'Действия',
-      dataIndex: 'actions',
-      render: (_: unknown, record: ProjectRow) => (
-        <Space>
-          <Button
-            icon={<EyeOutlined />}
-            onClick={() => openViewModal(record)}
-            aria-label="Просмотр"
-          />
-          <Button
-            icon={<EditOutlined />}
-            onClick={() => openEditModal(record)}
-            aria-label="Редактировать"
-          />
-          <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
-            <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
-          </Popconfirm>
-        </Space>
-      ),
-    },
-  ]
+  const columns: TableProps<ProjectRow>['columns'] = useMemo(
+    () => [
+      {
+        title: 'Название',
+        dataIndex: 'name',
+        sorter: (a: ProjectRow, b: ProjectRow) => a.name.localeCompare(b.name),
+        filters: nameFilters,
+        onFilter: (value: unknown, record: ProjectRow) => record.name === value,
+      },
+      {
+        title: 'Адрес',
+        dataIndex: 'address',
+        sorter: (a: ProjectRow, b: ProjectRow) =>
+          (a.address ?? '').localeCompare(b.address ?? ''),
+        filters: addressFilters,
+        onFilter: (value: unknown, record: ProjectRow) => record.address === value,
+      },
+      {
+        title: 'Кол-во корпусов',
+        dataIndex: 'blocks_count',
+        sorter: (a: ProjectRow, b: ProjectRow) =>
+          (a.blocks_count ?? 0) - (b.blocks_count ?? 0),
+        filters: blockCountFilters,
+        onFilter: (value: unknown, record: ProjectRow) => record.blocks_count === value,
+      },
+      {
+        title: 'Корпуса',
+        dataIndex: 'blockNames',
+        sorter: (a: ProjectRow, b: ProjectRow) =>
+          a.blockNames.join(';').localeCompare(b.blockNames.join(';')),
+        filters: blockNameFilters,
+        onFilter: (value: unknown, record: ProjectRow) =>
+          record.blockNames.includes(value as string),
+        render: (_: unknown, record: ProjectRow) =>
+          record.blocks
+            .map(
+              (b) =>
+                `${b.name} (${b.bottom_underground_floor ?? ''}; ${b.top_ground_floor ?? ''})`,
+            )
+            .join('; '),
+      },
+      {
+        title: 'Действия',
+        dataIndex: 'actions',
+        render: (_: unknown, record: ProjectRow) => (
+          <Space>
+            <Button
+              icon={<EyeOutlined />}
+              onClick={() => openViewModal(record)}
+              aria-label="Просмотр"
+            />
+            <Button
+              icon={<EditOutlined />}
+              onClick={() => openEditModal(record)}
+              aria-label="Редактировать"
+            />
+            <Popconfirm title="Удалить запись?" onConfirm={() => handleDelete(record)}>
+              <Button danger icon={<DeleteOutlined />} aria-label="Удалить" />
+            </Popconfirm>
+          </Space>
+        ),
+      },
+    ],
+    [
+      nameFilters,
+      addressFilters,
+      blockCountFilters,
+      blockNameFilters,
+      openViewModal,
+      openEditModal,
+      handleDelete,
+    ],
+  )
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- memoize editing handlers and column definitions in Locations reference table
- memoize action handlers and columns for Projects reference table
- filter undefined block counts in Projects filter generation to avoid runtime error
- replace per-row Popconfirm with Modal.confirm in Locations table to stop Ant Design CSS-in-JS cleanup warning

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd01e006c832e9493e52a6f3310ff