### PR TITLE
fix: sync menu trigger color with theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,13 +51,13 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
       <Sider
         theme={isDark ? 'dark' : 'light'}
         style={{
-          background: isDark ? '#555555' : '#EEF0F1',
+          background: 'var(--menu-bg)',
         }}
         collapsible
       >
         <div
           style={{
-            color: isDark ? '#ffffff' : '#000000',
+            color: 'var(--menu-color)',
             padding: 16,
             fontWeight: 600,
           }}
@@ -68,7 +68,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           theme={isDark ? 'dark' : 'light'}
           mode="inline"
           items={items}
-          style={{ background: isDark ? '#555555' : '#EEF0F1' }}
+          style={{ background: 'var(--menu-bg)' }}
         />
       </Sider>
       <Layout>

--- a/src/index.css
+++ b/src/index.css
@@ -7,14 +7,21 @@ body {
 
 body[data-theme='light'] {
   --menu-bg: #EEF0F1;
+  --menu-color: #000000;
 }
 
 body[data-theme='dark'] {
   --menu-bg: #555555;
+  --menu-color: #ffffff;
 }
 
 .ant-menu-dark,
 .ant-menu-dark .ant-menu-sub,
 .ant-menu-dark .ant-menu-submenu-popup {
   background: var(--menu-bg) !important;
+}
+
+.ant-layout-sider-trigger {
+  background: var(--menu-bg) !important;
+  color: var(--menu-color) !important;
 }


### PR DESCRIPTION
## Summary
- ensure menu collapse trigger inherits theme colors
- use CSS variables for menu background and text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cda8d2b78832e9b96a61f84cc5a49