### PR TITLE
fix: move add button to top right on chessboard page

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -494,51 +494,53 @@ export default function Chessboard() {
 
   return (
     <div>
-      <Space style={{ marginBottom: 16 }}>
-        <Select
-          placeholder="Проект"
-          style={{ width: 200 }}
-          value={filters.projectId}
-          onChange={(value) => setFilters({ projectId: value })}
-          options={projects?.map((p) => ({ value: p.id, label: p.name })) ?? []}
-        />
-        <Select
-          placeholder="Категория затрат"
-          style={{ width: 200 }}
-          value={filters.categoryId}
-          onChange={(value) =>
-            setFilters((f) => ({ ...f, categoryId: value, typeId: undefined }))
-          }
-          options={[
-            { value: '', label: 'НЕТ' },
-            ...(
-              costCategories?.map((c) => ({
-                value: String(c.id),
-                label: c.number ? `${c.number} ${c.name}` : c.name,
-              })) ?? []
-            ),
-          ]}
-        />
-        <Select
-          placeholder="Вид затрат"
-          style={{ width: 200 }}
-          value={filters.typeId}
-          onChange={(value) => setFilters((f) => ({ ...f, typeId: value }))}
-          options={[
-            { value: '', label: 'НЕТ' },
-            ...(
-              costTypes
-                ?.filter((t) => String(t.cost_category_id) === filters.categoryId)
-                .map((t) => ({ value: String(t.id), label: t.name })) ?? []
-            ),
-          ]}
-          disabled={!filters.categoryId}
-        />
-        <Button type="primary" onClick={handleApply} disabled={!filters.projectId}>
-          Применить
-        </Button>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <Space>
+          <Select
+            placeholder="Проект"
+            style={{ width: 200 }}
+            value={filters.projectId}
+            onChange={(value) => setFilters({ projectId: value })}
+            options={projects?.map((p) => ({ value: p.id, label: p.name })) ?? []}
+          />
+          <Select
+            placeholder="Категория затрат"
+            style={{ width: 200 }}
+            value={filters.categoryId}
+            onChange={(value) =>
+              setFilters((f) => ({ ...f, categoryId: value, typeId: undefined }))
+            }
+            options={[
+              { value: '', label: 'НЕТ' },
+              ...(
+                costCategories?.map((c) => ({
+                  value: String(c.id),
+                  label: c.number ? `${c.number} ${c.name}` : c.name,
+                })) ?? []
+              ),
+            ]}
+          />
+          <Select
+            placeholder="Вид затрат"
+            style={{ width: 200 }}
+            value={filters.typeId}
+            onChange={(value) => setFilters((f) => ({ ...f, typeId: value }))}
+            options={[
+              { value: '', label: 'НЕТ' },
+              ...(
+                costTypes
+                  ?.filter((t) => String(t.cost_category_id) === filters.categoryId)
+                  .map((t) => ({ value: String(t.id), label: t.name })) ?? []
+              ),
+            ]}
+            disabled={!filters.categoryId}
+          />
+          <Button type="primary" onClick={handleApply} disabled={!filters.projectId}>
+            Применить
+          </Button>
+        </Space>
         {appliedFilters && mode === 'view' && <Button onClick={startAdd}>Добавить</Button>}
-      </Space>
+      </div>
       {appliedFilters && mode === 'add' && (
         <>
           <Space style={{ marginBottom: 16 }}>


### PR DESCRIPTION
## Summary
- move add button to right side of chessboard filters

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce29e8dfc832ea5310bff9f827cc2