### PR TITLE
Автовыбор локализации на странице "Шахматка"

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -32,8 +32,13 @@ interface ViewRow {
 interface ProjectOption { id: string; name: string }
 interface UnitOption { id: string; name: string }
 interface CostCategoryOption { id: number; number: number | null; name: string }
-interface CostTypeOption { id: number; name: string; cost_category_id: number }
-interface LocationOption { id: string; name: string }
+interface CostTypeOption {
+  id: number
+  name: string
+  cost_category_id: number
+  location_id: number
+}
+interface LocationOption { id: number; name: string }
 
 interface DbRow {
   id: string
@@ -62,7 +67,7 @@ const emptyRow = (defaults: Partial<RowData>): RowData => ({
   unitId: '',
   costCategoryId: defaults.costCategoryId ?? '',
   costTypeId: defaults.costTypeId ?? '',
-  locationId: '',
+  locationId: defaults.locationId ?? '',
 })
 
 export default function Chessboard() {
@@ -113,7 +118,7 @@ export default function Chessboard() {
       if (!supabase) return []
       const { data, error } = await supabase
         .from('detail_cost_categories')
-        .select('id, name, cost_category_id')
+        .select('id, name, cost_category_id, location_id')
       if (error) throw error
       return data as CostTypeOption[]
     },
@@ -182,14 +187,20 @@ export default function Chessboard() {
 
   const addRow = useCallback(() => {
     if (!appliedFilters) return
+    const defaultLocationId = appliedFilters.typeId
+      ? String(
+          costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '',
+        )
+      : ''
     setRows((prev) => [
       ...prev,
       emptyRow({
         costCategoryId: appliedFilters.categoryId ?? '',
         costTypeId: appliedFilters.typeId ?? '',
+        locationId: defaultLocationId,
       }),
     ])
-  }, [appliedFilters])
+  }, [appliedFilters, costTypes])
 
   const handleRowChange = useCallback((key: string, field: keyof RowData, value: string) => {
     setRows((prev) => prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)))
@@ -197,14 +208,20 @@ export default function Chessboard() {
 
   const startAdd = useCallback(() => {
     if (!appliedFilters) return
+    const defaultLocationId = appliedFilters.typeId
+      ? String(
+          costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '',
+        )
+      : ''
     setRows([
       emptyRow({
         costCategoryId: appliedFilters.categoryId ?? '',
         costTypeId: appliedFilters.typeId ?? '',
+        locationId: defaultLocationId,
       }),
     ])
     setMode('add')
-  }, [appliedFilters])
+  }, [appliedFilters, costTypes])
 
   const startEdit = useCallback(
     (id: string) => {
@@ -394,6 +411,7 @@ export default function Chessboard() {
           onChange={(value) => {
             handleRowChange(record.key, 'costCategoryId', value)
             handleRowChange(record.key, 'costTypeId', '')
+            handleRowChange(record.key, 'locationId', '')
           }}
           options={
             costCategories?.map((c) => ({
@@ -411,7 +429,11 @@ export default function Chessboard() {
         <Select
           style={{ width: 200 }}
           value={record.costTypeId}
-          onChange={(value) => handleRowChange(record.key, 'costTypeId', value)}
+          onChange={(value) => {
+            handleRowChange(record.key, 'costTypeId', value)
+            const loc = costTypes?.find((t) => t.id === Number(value))?.location_id
+            handleRowChange(record.key, 'locationId', loc ? String(loc) : '')
+          }}
           options={
             costTypes
               ?.filter((t) => t.cost_category_id === Number(record.costCategoryId))
@@ -428,7 +450,7 @@ export default function Chessboard() {
           style={{ width: 200 }}
           value={record.locationId}
           onChange={(value) => handleRowChange(record.key, 'locationId', value)}
-          options={locations?.map((l) => ({ value: l.id, label: l.name })) ?? []}
+          options={locations?.map((l) => ({ value: String(l.id), label: l.name })) ?? []}
         />
       ),
     },


### PR DESCRIPTION
## Summary
- автоматически подставлять локализацию при выборе вида затрат
- корректно отображать значение локализации из справочника

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cea339b10832ea2f22ddc096e1af0