### PR TITLE
fix: keep existing chessboard rows visible when adding new entries

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -575,19 +575,32 @@ export default function Chessboard() {
         )}
       </div>
       {appliedFilters && mode === 'add' && (
-        <Table<RowData> dataSource={rows} columns={columns} pagination={false} rowKey="key" />
+        <Table<RowData>
+          dataSource={rows}
+          columns={columns}
+          pagination={false}
+          rowKey="key"
+          style={{ marginBottom: 16 }}
+        />
       )}
-      {appliedFilters && mode === 'edit' && (
-        <>
-          <Space style={{ marginBottom: 16 }}>
-            <Button onClick={handleUpdate}>Сохранить</Button>
-            <Button onClick={() => setMode('view')}>Отмена</Button>
-          </Space>
-          <Table<RowData> dataSource={rows} columns={editColumns} pagination={false} rowKey="key" />
-        </>
-      )}
-      {appliedFilters && mode === 'view' && (
-        <Table<ViewRow> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
+      {appliedFilters && (
+        mode === 'edit' ? (
+          <>
+            <Space style={{ marginBottom: 16 }}>
+              <Button onClick={handleUpdate}>Сохранить</Button>
+              <Button onClick={() => setMode('view')}>Отмена</Button>
+            </Space>
+            <Table<RowData> dataSource={rows} columns={editColumns} pagination={false} rowKey="key" />
+          </>
+        ) : (
+          <Table<ViewRow>
+            dataSource={viewRows}
+            columns={viewColumns}
+            pagination={false}
+            rowKey="key"
+            style={mode === 'add' ? { marginTop: 16 } : undefined}
+          />
+        )
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- ensure chessboard retains existing rows when adding new ones

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d6916530c832e89c236a16a213680