### PR TITLE
fix: keep chessboard data visible when adding rows

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -586,8 +586,14 @@ export default function Chessboard() {
           <Table<RowData> dataSource={rows} columns={editColumns} pagination={false} rowKey="key" />
         </>
       )}
-      {appliedFilters && mode === 'view' && (
-        <Table<ViewRow> dataSource={viewRows} columns={viewColumns} pagination={false} rowKey="key" />
+      {appliedFilters && mode !== 'edit' && (
+        <Table<ViewRow>
+          dataSource={viewRows}
+          columns={viewColumns}
+          pagination={false}
+          rowKey="key"
+          style={{ marginTop: mode === 'add' ? 16 : 0 }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- render existing chessboard data during add mode

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d6916530c832e89c236a16a213680