### PR TITLE
feat: add block filter to chessboard

### DIFF
--- a/sql/add_block_to_chessboard_mapping.sql
+++ b/sql/add_block_to_chessboard_mapping.sql
@@ -1,0 +1,3 @@
+-- Добавление связи записи шахматки с корпусом проекта
+alter table if exists chessboard_mapping
+  add column if not exists block_id uuid references blocks(id);


### PR DESCRIPTION
## Summary
- add "нет" option to block filter
- show project block column with sorting and filtering
- add SQL script to link chessboard rows with blocks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d9523238c832e8f88eafa3e68e8f4