### PR TITLE
fix: remove deprecated project fields

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -435,22 +435,8 @@
   },
   {
     "table_name": "projects",
-    "column_name": "description",
-    "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
     "column_name": "address",
     "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "blocks_count",
-    "data_type": "integer",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -25,7 +25,6 @@ interface Project {
   id: string
   name: string
   address: string | null
-  blocks_count: number | null
   created_at: string
   projects_blocks?: { block_id: string; blocks: BlockInfo | null }[] | null
 }
@@ -99,7 +98,7 @@ export default function Projects() {
       form.setFieldsValue({
         name: record.name,
         address: record.address,
-        blocks_count: blocks.length || record.blocks_count,
+        blocksCount: blocks.length,
         blocks,
       })
       setModalMode('edit')
@@ -125,7 +124,6 @@ export default function Projects() {
       const projectData = {
         name: values.name,
         address: values.address,
-        blocks_count: values.blocks_count,
       }
       if (modalMode === 'add') {
         const { data: project, error: projectError } = await supabase
@@ -237,18 +235,6 @@ export default function Projects() {
     [projects],
   )
 
-  const blockCountFilters = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          (projects ?? [])
-            .map((p) => p.blocks_count)
-            .filter((n): n is number => typeof n === 'number'),
-        ),
-      ).map((n) => ({ text: n.toString(), value: n })),
-    [projects],
-  )
-
   const blockNameFilters = useMemo(
     () =>
       Array.from(new Set(projectRows.flatMap((p) => p.blockNames))).map((n) => ({
@@ -274,14 +260,6 @@ export default function Projects() {
           (a.address ?? '').localeCompare(b.address ?? ''),
         filters: addressFilters,
         onFilter: (value: unknown, record: ProjectRow) => record.address === value,
-      },
-      {
-        title: 'Кол-во корпусов',
-        dataIndex: 'blocks_count',
-        sorter: (a: ProjectRow, b: ProjectRow) =>
-          (a.blocks_count ?? 0) - (b.blocks_count ?? 0),
-        filters: blockCountFilters,
-        onFilter: (value: unknown, record: ProjectRow) => record.blocks_count === value,
       },
       {
         title: 'Корпуса',
@@ -324,7 +302,6 @@ export default function Projects() {
     [
       nameFilters,
       addressFilters,
-      blockCountFilters,
       blockNameFilters,
       openViewModal,
       openEditModal,
@@ -370,7 +347,7 @@ export default function Projects() {
           <div>
             <p>Название: {currentProject?.name}</p>
             <p>Адрес: {currentProject?.address}</p>
-            <p>Количество корпусов: {currentProject?.blocks_count ?? ''}</p>
+            <p>Количество корпусов: {currentProject?.blocks.length ?? ''}</p>
             <p>
               Корпуса:{' '}
               {currentProject?.blocks
@@ -399,7 +376,7 @@ export default function Projects() {
             </Form.Item>
             <Form.Item
               label="Количество корпусов"
-              name="blocks_count"
+              name="blocksCount"
               rules={[{ required: true, message: 'Введите количество корпусов' }]}
             >
               <InputNumber min={1} onChange={handleBlocksCountChange} />

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,9 +1,7 @@
 create table if not exists projects (
   id uuid primary key default gen_random_uuid(),
   name text not null,
-  description text,
   address text,
-  blocks_count integer,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- drop description and blocks_count usage from projects
- remove block count column from projects table
## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e33b53d10832eb07f71973fc26caa