### PR TITLE
fix: remove deprecated project fields

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -435,22 +435,8 @@
   },
   {
     "table_name": "projects",
-    "column_name": "description",
-    "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
     "column_name": "address",
     "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "blocks_count",
-    "data_type": "integer",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,9 +1,7 @@
 create table if not exists projects (
   id uuid primary key default gen_random_uuid(),
   name text not null,
-  description text,
   address text,
-  blocks_count integer,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- drop unused project `description` and `blocks_count` fields
- adjust Projects page to generate block fields without saving count
- remove "Количество корпусов" column from Projects table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e33b53d10832eb07f71973fc26caa