### PR TITLE
fix: remove deprecated project fields

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -435,45 +435,10 @@
   },
   {
     "table_name": "projects",
-    "column_name": "description",
-    "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
     "column_name": "address",
     "data_type": "text",
     "is_nullable": "YES",
     "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "blocks_count",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "bottom_underground_floor",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "top_ground_floor",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "projects",
-    "column_name": "updated_at",
-    "data_type": "timestamp with time zone",
-    "is_nullable": "NO",
-    "column_default": "now()"
   },
   {
     "table_name": "projects_blocks",
@@ -488,20 +453,6 @@
     "data_type": "uuid",
     "is_nullable": "NO",
     "column_default": null
-  },
-  {
-    "table_name": "projects_blocks",
-    "column_name": "created_at",
-    "data_type": "timestamp with time zone",
-    "is_nullable": "NO",
-    "column_default": "now()"
-  },
-  {
-    "table_name": "projects_blocks",
-    "column_name": "updated_at",
-    "data_type": "timestamp with time zone",
-    "is_nullable": "NO",
-    "column_default": "now()"
   },
   {
     "table_name": "reference_data",

--- a/src/pages/references/Projects.tsx
+++ b/src/pages/references/Projects.tsx
@@ -25,8 +25,6 @@ interface Project {
   id: string
   name: string
   address: string | null
-  blocks_count: number | null
-  created_at: string
   projects_blocks?: { block_id: string; blocks: BlockInfo | null }[] | null
 }
 
@@ -51,15 +49,40 @@ export default function Projects() {
     queryKey: ['projects'],
     queryFn: async () => {
       if (!supabase) return []
-      const { data, error } = await supabase
+      const { data: projectData, error: projectError } = await supabase
         .from('projects')
-        .select('*, projects_blocks(block_id, blocks(name, bottom_underground_floor, top_ground_floor))')
-        .order('created_at', { ascending: false })
-      if (error) {
+        .select('id, name, address')
+        .order('name', { ascending: true })
+      if (projectError) {
         message.error('Не удалось загрузить данные')
-        throw error
+        throw projectError
       }
-      return data as Project[]
+      const projects = projectData as Project[]
+      const ids = projects.map((p) => p.id)
+      if (!ids.length) return projects
+      const { data: linkData, error: linkError } = await supabase
+        .from('projects_blocks')
+        .select('project_id, block_id, blocks(name, bottom_underground_floor, top_ground_floor)')
+        .in('project_id', ids)
+      if (linkError) {
+        message.error('Не удалось загрузить данные')
+        throw linkError
+      }
+      const linkRows = (linkData as unknown as {
+        project_id: string
+        block_id: string
+        blocks: BlockInfo | null
+      }[] | null) ?? []
+      const map = linkRows.reduce(
+        (acc, row) => {
+          const arr = acc[row.project_id] ?? []
+          arr.push({ block_id: row.block_id, blocks: row.blocks })
+          acc[row.project_id] = arr
+          return acc
+        },
+        {} as Record<string, { block_id: string; blocks: BlockInfo | null }[]>,
+      )
+      return projects.map((p) => ({ ...p, projects_blocks: map[p.id] ?? [] }))
     },
   })
 
@@ -99,7 +122,7 @@ export default function Projects() {
       form.setFieldsValue({
         name: record.name,
         address: record.address,
-        blocks_count: blocks.length || record.blocks_count,
+        blocksCount: blocks.length,
         blocks,
       })
       setModalMode('edit')
@@ -125,7 +148,6 @@ export default function Projects() {
       const projectData = {
         name: values.name,
         address: values.address,
-        blocks_count: values.blocks_count,
       }
       if (modalMode === 'add') {
         const { data: project, error: projectError } = await supabase
@@ -237,18 +259,6 @@ export default function Projects() {
     [projects],
   )
 
-  const blockCountFilters = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          (projects ?? [])
-            .map((p) => p.blocks_count)
-            .filter((n): n is number => typeof n === 'number'),
-        ),
-      ).map((n) => ({ text: n.toString(), value: n })),
-    [projects],
-  )
-
   const blockNameFilters = useMemo(
     () =>
       Array.from(new Set(projectRows.flatMap((p) => p.blockNames))).map((n) => ({
@@ -274,14 +284,6 @@ export default function Projects() {
           (a.address ?? '').localeCompare(b.address ?? ''),
         filters: addressFilters,
         onFilter: (value: unknown, record: ProjectRow) => record.address === value,
-      },
-      {
-        title: 'Кол-во корпусов',
-        dataIndex: 'blocks_count',
-        sorter: (a: ProjectRow, b: ProjectRow) =>
-          (a.blocks_count ?? 0) - (b.blocks_count ?? 0),
-        filters: blockCountFilters,
-        onFilter: (value: unknown, record: ProjectRow) => record.blocks_count === value,
       },
       {
         title: 'Корпуса',
@@ -321,15 +323,7 @@ export default function Projects() {
         ),
       },
     ],
-    [
-      nameFilters,
-      addressFilters,
-      blockCountFilters,
-      blockNameFilters,
-      openViewModal,
-      openEditModal,
-      handleDelete,
-    ],
+    [nameFilters, addressFilters, blockNameFilters, openViewModal, openEditModal, handleDelete],
   )
 
   return (
@@ -370,7 +364,7 @@ export default function Projects() {
           <div>
             <p>Название: {currentProject?.name}</p>
             <p>Адрес: {currentProject?.address}</p>
-            <p>Количество корпусов: {currentProject?.blocks_count ?? ''}</p>
+            <p>Количество корпусов: {currentProject?.blocks.length ?? 0}</p>
             <p>
               Корпуса:{' '}
               {currentProject?.blocks
@@ -399,7 +393,7 @@ export default function Projects() {
             </Form.Item>
             <Form.Item
               label="Количество корпусов"
-              name="blocks_count"
+              name="blocksCount"
               rules={[{ required: true, message: 'Введите количество корпусов' }]}
             >
               <InputNumber min={1} onChange={handleBlocksCountChange} />

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,9 +1,7 @@
 create table if not exists projects (
   id uuid primary key default gen_random_uuid(),
   name text not null,
-  description text,
   address text,
-  blocks_count integer,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- drop unused project `description` and `blocks_count` fields
- adjust Projects page to generate block fields without saving count
- remove "Количество корпусов" column from Projects table
- load related block data via separate `projects_blocks` query to avoid API errors
- remove reliance on `created_at` when listing projects

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e33b53d10832eb07f71973fc26caa