### PR TITLE
fix: keep chessboard horizontal scroll at page bottom

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -69,3 +69,19 @@ body[data-theme='dark'] {
 .row-purple * {
   color: #000000 !important;
 }
+
+/* Гарантируем, что горизонтальный скролл таблицы шахматки всегда внизу */
+.chessboard-table {
+  height: 100%;
+}
+
+.chessboard-table .ant-table-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.chessboard-table .ant-table-body {
+  flex: 1;
+  min-height: calc(100vh - 300px);
+}

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2321,37 +2321,41 @@ export default function Chessboard() {
       
       {/* Таблица */}
       {appliedFilters && (
-        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
           {mode === 'add' ? (
             <Table<TableRow>
-            dataSource={tableRows}
-            columns={orderedAddColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
-          />
-        ) : (
-          <Table<ViewRow>
-            dataSource={viewRows}
-            columns={orderedViewColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => {
-              const color = editingRows[record.key]?.color ?? record.color
-              return color ? `row-${color}` : ''
-            }}
-          />
-        )}
+              dataSource={tableRows}
+              columns={orderedAddColumns}
+              pagination={false}
+              rowKey="key"
+              sticky
+              className="chessboard-table"
+              style={{ flex: 1 }}
+              scroll={{
+                x: 'max-content',
+                y: 'calc(100vh - 300px)'
+              }}
+              rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
+            />
+          ) : (
+            <Table<ViewRow>
+              dataSource={viewRows}
+              columns={orderedViewColumns}
+              pagination={false}
+              rowKey="key"
+              sticky
+              className="chessboard-table"
+              style={{ flex: 1 }}
+              scroll={{
+                x: 'max-content',
+                y: 'calc(100vh - 300px)'
+              }}
+              rowClassName={(record) => {
+                const color = editingRows[record.key]?.color ?? record.color
+                return color ? `row-${color}` : ''
+              }}
+            />
+          )}
         </div>
       )}
       <Modal


### PR DESCRIPTION
## Summary
- stretch chessboard table to full height so horizontal scrollbar stays at the page bottom
- add global styles ensuring chessboard table body fills viewport height

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build` *(fails: TS17001 JSX elements cannot have multiple attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5476b7c8832e8ec95409b5840c08