### PR TITLE
fix: keep chessboard table scroll at page bottom

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2321,37 +2321,37 @@ export default function Chessboard() {
       
       {/* Таблица */}
       {appliedFilters && (
-        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
           {mode === 'add' ? (
             <Table<TableRow>
-            dataSource={tableRows}
-            columns={orderedAddColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
-          />
-        ) : (
-          <Table<ViewRow>
-            dataSource={viewRows}
-            columns={orderedViewColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => {
-              const color = editingRows[record.key]?.color ?? record.color
-              return color ? `row-${color}` : ''
-            }}
-          />
-        )}
+              dataSource={tableRows}
+              columns={orderedAddColumns}
+              pagination={false}
+              rowKey="key"
+              sticky
+              scroll={{
+                x: 'max-content',
+                y: '100%'
+              }}
+              rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
+            />
+          ) : (
+            <Table<ViewRow>
+              dataSource={viewRows}
+              columns={orderedViewColumns}
+              pagination={false}
+              rowKey="key"
+              sticky
+              scroll={{
+                x: 'max-content',
+                y: '100%'
+              }}
+              rowClassName={(record) => {
+                const color = editingRows[record.key]?.color ?? record.color
+                return color ? `row-${color}` : ''
+              }}
+            />
+          )}
         </div>
       )}
       <Modal


### PR DESCRIPTION
## Summary
- ensure Chessboard table scroll occupies full height so horizontal bar stays at page bottom

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build` *(fails: Property 'children' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5476b7c8832e8ec95409b5840c08