### PR TITLE
fix: pin chessboard scroll to page bottom

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect, type Key } from 'react'
+import { useCallback, useMemo, useState, type Key } from 'react'
 import { App, Badge, Button, Card, Checkbox, Drawer, Dropdown, Input, List, Modal, Popconfirm, Select, Space, Table, Typography, Upload } from 'antd'
 import type { ColumnType, ColumnsType } from 'antd/es/table'
 import { ArrowDownOutlined, ArrowUpOutlined, BgColorsOutlined, CopyOutlined, DeleteOutlined, EditOutlined, InboxOutlined, PlusOutlined, SaveOutlined, SettingOutlined, FilterOutlined, CaretUpFilled, CaretDownFilled, UploadOutlined } from '@ant-design/icons'
@@ -229,42 +229,6 @@ const collapseMap: Record<string, HiddenColKey> = {
 
 export default function Chessboard() {
   const { message } = App.useApp()
-  
-  // Диагностика скролла
-  useEffect(() => {
-    const checkScrollbars = () => {
-      const body = document.body
-      const html = document.documentElement
-      const mainContainer = document.querySelector('.ant-layout-content')
-      
-      console.log('🎯 Chessboard Scroll diagnostics:')
-      console.log('Body height:', body.scrollHeight, 'Client height:', body.clientHeight)
-      console.log('Body has scroll:', body.scrollHeight > body.clientHeight)
-      console.log('HTML height:', html.scrollHeight, 'Client height:', html.clientHeight)
-      console.log('HTML has scroll:', html.scrollHeight > html.clientHeight)
-      console.log('Window inner height:', window.innerHeight)
-      
-      if (mainContainer) {
-        console.log('Main content:', mainContainer.scrollHeight, mainContainer.clientHeight)
-        console.log('Main content overflow:', window.getComputedStyle(mainContainer).overflow)
-      }
-      
-      // Проверяем все элементы со скроллом
-      const scrollableElements = Array.from(document.querySelectorAll('*')).filter(el => {
-        const style = window.getComputedStyle(el)
-        return (style.overflow === 'auto' || style.overflow === 'scroll' || 
-                style.overflowY === 'auto' || style.overflowY === 'scroll') &&
-                el.scrollHeight > el.clientHeight
-      })
-      console.log('Elements with scroll:', scrollableElements.length)
-      scrollableElements.forEach(el => {
-        console.log('Scrollable element:', el.className || el.tagName, el.scrollHeight, el.clientHeight)
-      })
-    }
-    
-    setTimeout(checkScrollbars, 500)
-    return () => {}
-  })
   
   const [filters, setFilters] = useState<{ projectId?: string; blockId?: string; categoryId?: string; typeId?: string; tagId?: string; documentationId?: string }>({})
   const [appliedFilters, setAppliedFilters] = useState<
@@ -2321,37 +2285,37 @@ export default function Chessboard() {
       
       {/* Таблица */}
       {appliedFilters && (
-        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
-          {mode === 'add' ? (
-            <Table<TableRow>
-            dataSource={tableRows}
-            columns={orderedAddColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
-          />
-        ) : (
-          <Table<ViewRow>
-            dataSource={viewRows}
-            columns={orderedViewColumns}
-            pagination={false}
-            rowKey="key"
-            sticky
-            scroll={{ 
-              x: 'max-content',
-              y: 'calc(100vh - 300px)'
-            }}
-            rowClassName={(record) => {
-              const color = editingRows[record.key]?.color ?? record.color
-              return color ? `row-${color}` : ''
-            }}
-          />
-        )}
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <div style={{ height: '100%', overflow: 'auto' }}>
+            {mode === 'add' ? (
+              <Table<TableRow>
+                dataSource={tableRows}
+                columns={orderedAddColumns}
+                pagination={false}
+                rowKey="key"
+                sticky
+                scroll={{
+                  x: 'max-content'
+                }}
+                rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
+              />
+            ) : (
+              <Table<ViewRow>
+                dataSource={viewRows}
+                columns={orderedViewColumns}
+                pagination={false}
+                rowKey="key"
+                sticky
+                scroll={{
+                  x: 'max-content'
+                }}
+                rowClassName={(record) => {
+                  const color = editingRows[record.key]?.color ?? record.color
+                  return color ? `row-${color}` : ''
+                }}
+              />
+            )}
+          </div>
         </div>
       )}
       <Modal


### PR DESCRIPTION
## Summary
- ensure Chessboard table fills remaining viewport and scrollbars appear at page bottom
- remove temporary scroll diagnostics

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build` *(fails: JSX duplicate attributes & missing children props)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5476b7c8832e8ec95409b5840c08