### PR TITLE
fix: map rates to detail cost categories

### DIFF
--- a/src/entities/rates/model/types.ts
+++ b/src/entities/rates/model/types.ts
@@ -23,11 +23,6 @@ export interface RateWithRelations extends Rate {
       number: number
     }
   }
-  cost_categories?: Array<{
-    id: number
-    name: string
-    number: number
-  }>
 }
 
 export interface RateExcelRow {
@@ -45,5 +40,4 @@ export interface RateFormData {
   base_rate: number
   unit_id?: string
   detail_cost_category_id?: number
-  cost_category_ids: number[]
 }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -4,7 +4,7 @@ export const formatDate = (date: string | Date): string => {
   return d.toLocaleDateString('ru-RU')
 }
 
-export const debounce = <T extends (...args: any[]) => any>(
+export const debounce = <T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number,
 ): ((...args: Parameters<T>) => void) => {


### PR DESCRIPTION
## Summary
- link rates to detail cost categories during Excel import
- adjust API and types for cost category relation via detail categories
- update rates page to show cost category derived from cost type

## Testing
- `npm run lint` (fails: Unexpected any in documentation and projects modules)
- `npm run build` (fails: TypeScript errors in Chessboard page)


------
https://chatgpt.com/codex/tasks/task_e_68ac71dfe210832e98ce2a29a0615c60