### PR TITLE
fix: map rates to detail cost categories

### DIFF
--- a/src/entities/rates/api/rates-api.ts
+++ b/src/entities/rates/api/rates-api.ts
@@ -14,8 +14,8 @@ export const ratesApi = {
       .select(`
         *,
         unit:units(id, name),
-        cost_categories:rates_cost_categories_mapping(
-          cost_category:cost_categories(id, name, number)
+        detail_mapping:rates_detail_cost_categories_mapping(
+          detail_cost_category:detail_cost_categories(id, name, cost_category:cost_categories(id, name, number))
         )
       `)
       .order('created_at', { ascending: false })
@@ -27,11 +27,14 @@ export const ratesApi = {
       throw error
     }
     
-    const result = data.map(rate => ({
-      ...rate,
-      cost_categories: rate.cost_categories?.map((mapping: any) => mapping.cost_category).filter(Boolean) || [],
-      detail_cost_category: null
-    })) as RateWithRelations[]
+    const result = data.map(({ detail_mapping, ...rate }) => {
+      const detailCategory = detail_mapping?.[0]?.detail_cost_category
+      return {
+        ...rate,
+        detail_cost_category: detailCategory || null,
+        detail_cost_category_id: detailCategory?.id
+      }
+    }) as RateWithRelations[]
     
     console.log('✅ Данные обработаны', { count: result.length, result })
     return result
@@ -40,12 +43,12 @@ export const ratesApi = {
   async create(data: RateFormData): Promise<Rate> {
     if (!supabase) throw new Error('Supabase is not configured')
     
-    const { cost_category_ids, detail_cost_category_id, ...rateData } = data
-    
+    const { detail_cost_category_id, ...rateData } = data
+
     // Создаем запись расценки
     const { data: rate, error: rateError } = await supabase
       .from('rates')
-      .insert(rateData)
+      .insert({ ...rateData })
       .select()
       .single()
     
@@ -54,19 +57,14 @@ export const ratesApi = {
       throw rateError
     }
     
-    // Создаем связи с категориями затрат
-    if (cost_category_ids.length > 0) {
-      const mappings = cost_category_ids.map(cost_category_id => ({
-        rate_id: rate.id,
-        cost_category_id
-      }))
-      
+    // Создаем связь с видом затрат
+    if (detail_cost_category_id) {
       const { error: mappingError } = await supabase
-        .from('rates_cost_categories_mapping')
-        .insert(mappings)
-      
+        .from('rates_detail_cost_categories_mapping')
+        .insert({ rate_id: rate.id, detail_cost_category_id })
+
       if (mappingError) {
-        console.error('Failed to create rate-cost category mappings:', mappingError)
+        console.error('Failed to create rate-detail cost category mapping:', mappingError)
         throw mappingError
       }
     }
@@ -77,12 +75,12 @@ export const ratesApi = {
   async update(id: string, data: RateFormData): Promise<Rate> {
     if (!supabase) throw new Error('Supabase is not configured')
     
-    const { cost_category_ids, detail_cost_category_id, ...rateData } = data
-    
+    const { detail_cost_category_id, ...rateData } = data
+
     // Обновляем запись расценки
     const { data: rate, error: rateError } = await supabase
       .from('rates')
-      .update(rateData)
+      .update({ ...rateData })
       .eq('id', id)
       .select()
       .single()
@@ -92,31 +90,26 @@ export const ratesApi = {
       throw rateError
     }
     
-    // Обновляем связи с категориями затрат
+    // Обновляем связь с видом затрат
     // Удаляем старые связи
     const { error: deleteError } = await supabase
-      .from('rates_cost_categories_mapping')
+      .from('rates_detail_cost_categories_mapping')
       .delete()
       .eq('rate_id', id)
-    
+
     if (deleteError) {
-      console.error('Failed to delete old rate-cost category mappings:', deleteError)
+      console.error('Failed to delete old rate-detail cost category mapping:', deleteError)
       throw deleteError
     }
-    
-    // Создаем новые связи
-    if (cost_category_ids.length > 0) {
-      const mappings = cost_category_ids.map(cost_category_id => ({
-        rate_id: id,
-        cost_category_id
-      }))
-      
+
+    // Создаем новую связь
+    if (detail_cost_category_id) {
       const { error: mappingError } = await supabase
-        .from('rates_cost_categories_mapping')
-        .insert(mappings)
-      
+        .from('rates_detail_cost_categories_mapping')
+        .insert({ rate_id: id, detail_cost_category_id })
+
       if (mappingError) {
-        console.error('Failed to create new rate-cost category mappings:', mappingError)
+        console.error('Failed to create new rate-detail cost category mapping:', mappingError)
         throw mappingError
       }
     }

--- a/src/entities/rates/model/types.ts
+++ b/src/entities/rates/model/types.ts
@@ -4,7 +4,6 @@ export interface Rate {
   work_set?: string // РАБОЧИЙ НАБОР
   base_rate: number // Расценка БАЗОВАЯ
   unit_id?: string // Ед.изм.
-  detail_cost_category_id?: number // Вид затрат
   created_at: string
   updated_at: string
 }
@@ -23,11 +22,7 @@ export interface RateWithRelations extends Rate {
       number: number
     }
   }
-  cost_categories?: Array<{
-    id: number
-    name: string
-    number: number
-  }>
+  detail_cost_category_id?: number
 }
 
 export interface RateExcelRow {
@@ -45,5 +40,4 @@ export interface RateFormData {
   base_rate: number
   unit_id?: string
   detail_cost_category_id?: number
-  cost_category_ids: number[]
 }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -4,7 +4,7 @@ export const formatDate = (date: string | Date): string => {
   return d.toLocaleDateString('ru-RU')
 }
 
-export const debounce = <T extends (...args: any[]) => any>(
+export const debounce = <T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number,
 ): ((...args: Parameters<T>) => void) => {


### PR DESCRIPTION
## Summary
- link rates to detail cost categories during Excel import
- adjust API and types for cost category relation via detail categories
- update rates page to show cost category derived from cost type

## Testing
- `npm run lint` (fails: Unexpected any in documentation and projects modules)
- `npm run build` (fails: TypeScript errors in Chessboard page)


------
https://chatgpt.com/codex/tasks/task_e_68ac71dfe210832e98ce2a29a0615c60