### PR TITLE
feat: add work name selection to chessboard

### DIFF
--- a/src/entities/chessboard/api/chessboard-api.ts
+++ b/src/entities/chessboard/api/chessboard-api.ts
@@ -24,7 +24,9 @@ export const chessboardApi = {
   async create(row: Partial<ChessboardRow>) {
     if (!supabase) throw new Error('Supabase is not configured')
     
-    const { data, error } = await supabase.from('chessboard').insert(row).select()
+    const { rateId, ...rest } = row
+    const payload = { ...rest, rate_id: rateId }
+    const { data, error } = await supabase.from('chessboard').insert(payload).select()
     
     if (error) {
       console.error('Failed to create chessboard row:', error)
@@ -37,9 +39,11 @@ export const chessboardApi = {
   async update(id: string, updates: Partial<ChessboardRow>) {
     if (!supabase) throw new Error('Supabase is not configured')
     
+    const { rateId, ...rest } = updates
+    const payload = { ...rest, rate_id: rateId }
     const { data, error } = await supabase
       .from('chessboard')
-      .update(updates)
+      .update(payload)
       .eq('id', id)
       .select()
     

--- a/src/entities/chessboard/model/types.ts
+++ b/src/entities/chessboard/model/types.ts
@@ -8,6 +8,7 @@ export interface ChessboardRow extends BaseEntity {
   unitId: string
   blockId: string
   block: string
+  rateId: string
   costCategoryId: string
   costTypeId: string
   locationId: string

--- a/src/entities/rates/api/rates-api.ts
+++ b/src/entities/rates/api/rates-api.ts
@@ -29,10 +29,12 @@ export const ratesApi = {
     
     const result = data.map(({ detail_mapping, ...rate }) => {
       const detailCategory = detail_mapping?.[0]?.detail_cost_category
+      const costCategoryId = detailCategory?.cost_category?.id
       return {
         ...rate,
         detail_cost_category: detailCategory || null,
-        detail_cost_category_id: detailCategory?.id
+        detail_cost_category_id: detailCategory?.id,
+        cost_category_ids: costCategoryId ? [costCategoryId] : [],
       }
     }) as RateWithRelations[]
     

--- a/src/entities/rates/model/types.ts
+++ b/src/entities/rates/model/types.ts
@@ -23,6 +23,7 @@ export interface RateWithRelations extends Rate {
     }
   }
   detail_cost_category_id?: number
+  cost_category_ids?: number[]
 }
 
 export interface RateExcelRow {


### PR DESCRIPTION
## Summary
- add "Наименование работ" column to Chessboard with rate dictionary and filtering
- expose rate and cost category mappings in rates API
- support rate reference in chessboard entities
- clean rate query and Select filter logic

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac8330cc94832e8d7b094720fac0f3