### PR TITLE
feat: add page scale control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,14 +19,15 @@ import DocumentationTags from './pages/admin/DocumentationTags'
 import Statuses from './pages/admin/Statuses'
 import PortalHeader from './components/PortalHeader'
 import TestTableStructure from './pages/TestTableStructure'
+import { scaleOptions, ScaleValue } from './shared/scale'
 
 const { Sider, Content } = Layout
 
 interface AppProps {
   isDark: boolean
   toggleTheme: () => void
-  scale: number
-  onScaleChange: (value: number) => void
+  scale: ScaleValue
+  onScaleChange: (value: ScaleValue) => void
 }
 
 const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
@@ -225,15 +226,6 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
       </div>
     </div>
   )
-
-    const scaleOptions = [
-      { value: 0.7, label: '70%' },
-      { value: 0.8, label: '80%' },
-      { value: 0.9, label: '90%' },
-      { value: 1, label: '100%' },
-      { value: 1.1, label: '110%' },
-      { value: 1.2, label: '120%' },
-    ]
 
     const adminSubmenu = (
       <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { ConfigProvider, App as AntdApp, unstableSetRender, theme } from 'antd'
 import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
+import { parseScale, ScaleValue } from './shared/scale'
 
 unstableSetRender((node, container) => {
   const root = createRoot(container)
@@ -26,10 +27,7 @@ export function Root() {
     const savedTheme = localStorage.getItem(themeStorageKey)
     return savedTheme === 'dark'
   })
-  const [scale, setScale] = useState(() => {
-    const savedScale = localStorage.getItem(scaleStorageKey)
-    return savedScale ? Number(savedScale) : 1
-  })
+  const [scale, setScale] = useState<ScaleValue>(() => parseScale(localStorage.getItem(scaleStorageKey)))
 
   useEffect(() => {
     document.body.style.backgroundColor = isDark ? '#555555' : '#FCFCFC'

--- a/src/shared/scale.ts
+++ b/src/shared/scale.ts
@@ -1,0 +1,13 @@
+export type ScaleValue = 0.7 | 0.8 | 0.9 | 1 | 1.1 | 1.2;
+
+export const SCALE_VALUES: ScaleValue[] = [0.7, 0.8, 0.9, 1, 1.1, 1.2];
+
+export const scaleOptions = SCALE_VALUES.map((value) => ({
+  value,
+  label: `${Math.round(value * 100)}%`,
+}));
+
+export const parseScale = (value: string | null): ScaleValue => {
+  const num = Number(value);
+  return SCALE_VALUES.includes(num as ScaleValue) ? (num as ScaleValue) : 1;
+};


### PR DESCRIPTION
## Summary
- add page scale selection in admin menu
- persist scale per user and apply to root element
- ensure page stretches vertically when scaled

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars in multiple files)*
- `npm run build` *(fails: TS errors in Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9c2768e4832e80cf393d2ff15fc4