### PR TITLE
feat: add persistent portal scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,7 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
     </div>
   )
 
-    const scaleOptions = [
+    const scaleOptions: { value: number; label: string }[] = [
       { value: 0.7, label: '70%' },
       { value: 0.8, label: '80%' },
       { value: 0.9, label: '90%' },

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,6 +40,7 @@ export function Root() {
       root.style.transform = `scale(${scale})`
       root.style.transformOrigin = 'top left'
       root.style.width = `${100 / scale}%`
+      root.style.height = `${100 / scale}%`
     }
     localStorage.setItem('blueprintflow-scale', String(scale))
   }, [scale])


### PR DESCRIPTION
## Summary
- add scale selector in admin menu
- persist chosen scale and apply transform to root element
- ensure portal occupies full window

## Testing
- `npm run lint` *(fails: Unexpected any, unused variables)*
- `npm run build` *(fails: TS errors in Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4d67eac832e8b1298c288b9ccaf