### PR TITLE
feat: add persistent portal scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,7 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
     </div>
   )
 
-    const scaleOptions = [
+    const scaleOptions: { value: number; label: string }[] = [
       { value: 0.7, label: '70%' },
       { value: 0.8, label: '80%' },
       { value: 0.9, label: '90%' },
@@ -491,13 +491,16 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
             onOpenChange={setOpenKeys}
           />
         </Sider>
-        <Layout>
+        <Layout style={{ minHeight: '100%' }}>
           <PortalHeader isDark={isDark} />
           <Content
             style={{
               margin: 16,
               background: isDark ? '#555555' : '#FCFCFC',
               color: isDark ? '#ffffff' : '#000000',
+              flex: 1,
+              boxSizing: 'border-box',
+              height: 'calc(100% - 64px - 32px)',
             }}
           >
             <Routes>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -66,7 +66,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
           style={{ background: '#333333' }}
         />
       </Sider>
-      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s' }}>
+      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s', minHeight: '100%' }}>
         <div style={{ 
           position: 'fixed', 
           top: 0, 
@@ -78,12 +78,13 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         }}>
           <PortalHeader isDark={isDark} />
         </div>
-        <Content style={{ 
-          marginTop: 64, 
-          padding: '16px', 
-          background: '#333333', 
+        <Content style={{
+          marginTop: 64,
+          padding: '16px',
+          background: '#333333',
           color: '#ffffff',
-          minHeight: 'calc(100vh - 64px)'
+          height: 'calc(100% - 64px)',
+          boxSizing: 'border-box'
         }}>
           {children}
         </Content>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,6 +40,7 @@ export function Root() {
       root.style.transform = `scale(${scale})`
       root.style.transformOrigin = 'top left'
       root.style.width = `${100 / scale}%`
+      root.style.height = `${100 / scale}%`
     }
     localStorage.setItem('blueprintflow-scale', String(scale))
   }, [scale])


### PR DESCRIPTION
## Summary
- add scale selector in admin menu
- persist chosen scale and apply transform to root element
- ensure portal occupies full window vertically and horizontally

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run build` *(fails: TS errors in Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4d67eac832e8b1298c288b9ccaf