### PR TITLE
feat: support persistent page scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -457,7 +457,7 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
           }
         `}
       </style>
-      <Layout style={{ height: '100%' }}>
+      <Layout style={{ minHeight: '100vh' }}>
         <Sider
           theme={isDark ? 'dark' : 'light'}
           style={{
@@ -491,14 +491,16 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
             onOpenChange={setOpenKeys}
           />
         </Sider>
-        <Layout style={{ height: '100%' }}>
+        <Layout style={{ minHeight: '100vh' }}>
           <PortalHeader isDark={isDark} />
           <Content
             style={{
               margin: 16,
               background: isDark ? '#555555' : '#FCFCFC',
               color: isDark ? '#ffffff' : '#000000',
-              flex: 1,
+              boxSizing: 'border-box',
+              height: 'calc(100vh - 64px - 32px)',
+              overflow: 'auto',
             }}
           >
             <Routes>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@ html,
 body,
 #root {
   height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -41,7 +41,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const [collapsed, setCollapsed] = useState(false);
   const siderWidth = collapsed ? 80 : 200;
   return (
-    <Layout style={{ height: '100%' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Sider 
         theme="dark" 
         style={{ 
@@ -66,25 +66,29 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
           style={{ background: '#333333' }}
         />
       </Sider>
-      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s' }}>
-        <div style={{ 
-          position: 'fixed', 
-          top: 0, 
-          right: 0, 
-          left: siderWidth, 
+      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s', minHeight: '100vh' }}>
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          left: siderWidth,
           zIndex: 99,
           background: '#333333',
           transition: 'left 0.2s'
         }}>
           <PortalHeader isDark={isDark} />
         </div>
-        <Content style={{
-          marginTop: 64,
-          padding: '16px',
-          background: '#333333',
-          color: '#ffffff',
-          height: 'calc(100% - 64px)'
-        }}>
+        <Content
+          style={{
+            marginTop: 64,
+            padding: 16,
+            background: '#333333',
+            color: '#ffffff',
+            boxSizing: 'border-box',
+            height: 'calc(100vh - 64px)',
+            overflow: 'auto'
+          }}
+        >
           {children}
         </Content>
       </Layout>


### PR DESCRIPTION
## Summary
- allow choosing page scale in administration
- stretch layouts to full viewport height for proper scaling

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm run build` (fails: Property 'children' does not exist...)


------
https://chatgpt.com/codex/tasks/task_e_68adb0f38640832eadd85765181e015c