### PR TITLE
feat: support persistent page scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -498,7 +498,9 @@ const App = ({ isDark, toggleTheme, scale, onScaleChange }: AppProps) => {
               margin: 16,
               background: isDark ? '#555555' : '#FCFCFC',
               color: isDark ? '#ffffff' : '#000000',
-              flex: 1,
+              boxSizing: 'border-box',
+              height: 'calc(100% - 64px - 32px)',
+              overflow: 'auto',
             }}
           >
             <Routes>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,19 @@
 html,
-body,
+body {
+  height: 100%;
+  min-height: 100vh;
+  width: 100%;
+  overflow: hidden;
+}
+
 #root {
   height: 100%;
+  min-height: 100vh;
+  width: 100%;
+}
+
+/* Ensure Ant Design tables always expand to the available width */
+.ant-table {
   width: 100%;
 }
 

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -66,25 +66,30 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
           style={{ background: '#333333' }}
         />
       </Sider>
-      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s' }}>
-        <div style={{ 
-          position: 'fixed', 
-          top: 0, 
-          right: 0, 
-          left: siderWidth, 
+      <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s', height: '100%' }}>
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          left: siderWidth,
           zIndex: 99,
           background: '#333333',
           transition: 'left 0.2s'
         }}>
           <PortalHeader isDark={isDark} />
         </div>
-        <Content style={{
-          marginTop: 64,
-          padding: '16px',
-          background: '#333333',
-          color: '#ffffff',
-          height: 'calc(100% - 64px)'
-        }}>
+        <Content
+          style={{
+            marginTop: 64,
+            padding: 16,
+            background: '#333333',
+            color: '#ffffff',
+            boxSizing: 'border-box',
+            height: 'calc(100% - 64px)',
+            overflow: 'auto',
+            width: '100%'
+          }}
+        >
           {children}
         </Content>
       </Layout>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,12 +35,12 @@ export function Root() {
   }, [isDark])
 
   useEffect(() => {
-    const root = document.getElementById('root')
-    if (root) {
-      root.style.transform = `scale(${scale})`
-      root.style.transformOrigin = 'top left'
-      root.style.width = `${100 / scale}%`
-      root.style.height = `${100 / scale}%`
+    const rootElement = document.getElementById('root')
+    if (rootElement) {
+      rootElement.style.transform = `scale(${scale})`
+      rootElement.style.transformOrigin = '0 0'
+      rootElement.style.width = `${100 / scale}vw`
+      rootElement.style.height = `${100 / scale}vh`
     }
     localStorage.setItem('blueprintflow-scale', String(scale))
   }, [scale])


### PR DESCRIPTION
## Summary
- allow choosing page scale in administration
- stretch layouts to full viewport height for proper scaling
- ensure tables expand with portal zoom

## Testing
- `npm run lint` (fails: Unexpected any...)
- `npm run build` (fails: TS17001, TS2339 in Chessboard.tsx...)


------
https://chatgpt.com/codex/tasks/task_e_68adb0f38640832eadd85765181e015c