### PR TITLE
feat: integrate yandex disk storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Rates from './pages/references/Rates'
 import Admin from './pages/Admin'
 import DocumentationTags from './pages/admin/DocumentationTags'
 import Statuses from './pages/admin/Statuses'
+import Disk from './pages/admin/Disk'
 import PortalHeader from './components/PortalHeader'
 import TestTableStructure from './pages/TestTableStructure'
 
@@ -235,7 +236,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           Тэги документации
         </Link>
       </div>
-      <div 
+      <div
         style={menuItemStyle}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
         onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
@@ -244,7 +245,16 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           Статусы
         </Link>
       </div>
-      <div 
+      <div
+        style={menuItemStyle}
+        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
+        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+      >
+        <Link to="/admin/disk" style={linkStyle}>
+          Диск
+        </Link>
+      </div>
+      <div
         style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
         onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
@@ -301,13 +311,17 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
       label: collapsed ? '' : 'Администрирование',
       title: collapsed ? '' : undefined,
       children: collapsed ? undefined : [
-        { 
-          key: 'documentation-tags', 
+        {
+          key: 'documentation-tags',
           label: <Link to="/admin/documentation-tags">Тэги документации</Link>
         },
         {
           key: 'statuses',
           label: <Link to="/admin/statuses">Статусы</Link>
+        },
+        {
+          key: 'disk',
+          label: <Link to="/admin/disk">Диск</Link>
         },
         {
           key: 'theme-toggle',
@@ -445,6 +459,8 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               location.pathname.startsWith('/references/rates') ? 'rates' :
               location.pathname.startsWith('/references') ? 'units' :
               location.pathname.startsWith('/admin/documentation-tags') ? 'documentation-tags' :
+              location.pathname.startsWith('/admin/statuses') ? 'statuses' :
+              location.pathname.startsWith('/admin/disk') ? 'disk' :
               location.pathname
             ]}
             openKeys={openKeys}
@@ -477,6 +493,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               <Route path="/admin" element={<Admin />}>
                 <Route path="documentation-tags" element={<DocumentationTags />} />
                 <Route path="statuses" element={<Statuses />} />
+                <Route path="disk" element={<Disk />} />
               </Route>
               <Route path="/test-table" element={<TestTableStructure />} />
             </Routes>

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
-import { Upload, Button, Space, Typography, Tooltip, App, Dropdown, Modal } from 'antd'
+import { Upload, Button, Space, Typography, Tooltip, Dropdown, Modal, App } from 'antd'
 import { UploadOutlined, FileExcelOutlined, FileWordOutlined, FilePdfOutlined, FileOutlined, DeleteOutlined, DownloadOutlined, EyeOutlined } from '@ant-design/icons'
 import type { UploadProps } from 'antd/es/upload'
 import type { MenuProps } from 'antd'
 import type { LocalFile } from '@/entities/documentation'
+import { diskApi } from '@/entities/disk'
+import { transliterate } from '@/lib/transliterate'
 
 const { Text } = Typography
 
@@ -11,12 +13,12 @@ interface FileUploadProps {
   files: LocalFile[]
   onChange: (files: LocalFile[]) => void
   disabled?: boolean
-  projectId: string
+  projectCode: string
+  sectionName: string
   documentationCode: string
   onlineFileUrl?: string
 }
 
-// Функция для получения иконки по расширению файла
 const getFileIcon = (extension: string) => {
   const ext = extension.toLowerCase()
   switch (ext) {
@@ -35,87 +37,71 @@ const getFileIcon = (extension: string) => {
   }
 }
 
+const uploadToYandexDisk = async (
+  file: File,
+  projectCode: string,
+  sectionName: string,
+  documentationCode: string
+): Promise<{ url: string; path: string }> => {
+  const settings = await diskApi.getSettings()
+  if (!settings) throw new Error('Disk settings not configured')
 
-// Функция для создания пути к файлу (используем прямые слэши для веб)
-const createFilePath = (projectId: string, documentationCode: string, fileName: string): string => {
-  return `./Documentation/${projectId}/${documentationCode}/${fileName}`
-}
+  const folderPath = `${settings.base_path}/${transliterate(projectCode)}/${transliterate(sectionName)}/${transliterate(documentationCode)}`
+  const filePath = `${folderPath}/${file.name}`
 
-// Функция для сохранения файла локально в папку public
-const saveFileLocally = async (file: File, filePath: string, projectId: string, documentationCode: string): Promise<string> => {
-  try {
-    // Создаем папку если она не существует (через API или mock)
-    const fullPath = `public${filePath}`
-    
-    // В реальном браузерном приложении нельзя напрямую записывать в файловую систему
-    // Эмулируем сохранение через создание blob URL для доступа к файлу
-    const arrayBuffer = await file.arrayBuffer()
-    const blob = new Blob([arrayBuffer], { type: file.type })
-    const blobUrl = URL.createObjectURL(blob)
-    
-    // Сохраняем blob URL в sessionStorage для доступа к файлу в текущей сессии
-    const fileKey = `file_${projectId}_${documentationCode}_${file.name}`
-    sessionStorage.setItem(fileKey, blobUrl)
-    
-    console.log(`✅ File ${file.name} saved to ${fullPath}`)
-    console.log(`📁 Local path: C:\\Users\\eugene\\WebstormProjects\\blueprintflow\\public${filePath}`)
-    console.log(`🔗 Blob URL stored in session: ${blobUrl}`)
-    
-    return fullPath
-  } catch (error) {
-    console.error('❌ Error saving file:', error)
-    throw error
+  const res = await fetch(`https://cloud-api.yandex.net/v1/disk/resources/upload?path=${encodeURIComponent(filePath)}&overwrite=true`, {
+    headers: { Authorization: `OAuth ${settings.token}` },
+  })
+  const { href } = await res.json()
+  await fetch(href, { method: 'PUT', body: file })
+
+  let publicUrl = ''
+  if (settings.make_public) {
+    await fetch(`https://cloud-api.yandex.net/v1/disk/resources/publish?path=${encodeURIComponent(filePath)}`, {
+      method: 'PUT',
+      headers: { Authorization: `OAuth ${settings.token}` },
+    })
+    const infoRes = await fetch(`https://cloud-api.yandex.net/v1/disk/resources?path=${encodeURIComponent(filePath)}&fields=public_url`, {
+      headers: { Authorization: `OAuth ${settings.token}` },
+    })
+    const info = await infoRes.json()
+    publicUrl = info.public_url
   }
+
+  return { url: publicUrl, path: filePath }
 }
 
-export default function FileUpload({ files, onChange, disabled, projectId, documentationCode, onlineFileUrl }: FileUploadProps) {
+export default function FileUpload({ files, onChange, disabled, projectCode, sectionName, documentationCode, onlineFileUrl }: FileUploadProps) {
   const [uploading, setUploading] = useState(false)
   const [previewModalOpen, setPreviewModalOpen] = useState(false)
   const [previewFile, setPreviewFile] = useState<LocalFile | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string>('')
   const { modal, message } = App.useApp()
 
-  const handleUpload: UploadProps['customRequest'] = async (options) => {
-    const { file, onSuccess, onError } = options
-    
+  const handleUpload: UploadProps['customRequest'] = async ({ file, onSuccess, onError }) => {
     if (!(file instanceof File)) {
       onError?.(new Error('Invalid file'))
       return
     }
-
     setUploading(true)
-
     try {
       const extension = file.name.split('.').pop() || ''
-      const filePath = createFilePath(projectId, documentationCode, file.name)
-
-      // Сохраняем файл локально и получаем реальный путь
-      const savedPath = await saveFileLocally(file, filePath, projectId, documentationCode)
-
-      // Создаем объект LocalFile с дополнительной информацией
+      const { url, path } = await uploadToYandexDisk(file, projectCode, sectionName, documentationCode)
       const newFile: LocalFile = {
         name: file.name,
-        path: savedPath, // Используем полный путь
+        path,
+        url,
         size: file.size,
         type: file.type,
         extension,
         uploadedAt: new Date().toISOString(),
       }
-
-      // Добавляем файл к существующим
       const updatedFiles = [...files, newFile]
       onChange(updatedFiles)
-
       onSuccess?.(null, file as unknown as XMLHttpRequestResponseType)
-      
-      console.log(`🎉 Upload completed successfully:`, {
-        fileName: file.name,
-        localPath: `C:\\Users\\eugene\\WebstormProjects\\blueprintflow\\${savedPath}`,
-        size: `${(file.size / 1024 / 1024).toFixed(2)} MB`
-      })
-    } catch (error) {
-      console.error('❌ Error uploading file:', error)
-      onError?.(error as Error)
+    } catch (e) {
+      console.error('❌ Error uploading file:', e)
+      onError?.(e as Error)
     } finally {
       setUploading(false)
     }
@@ -131,186 +117,62 @@ export default function FileUpload({ files, onChange, disabled, projectId, docum
       onOk: async () => {
         try {
           const updatedFiles = files.filter(f => f.path !== fileToRemove.path)
-          // Вызываем onChange для обновления данных в базе
           await onChange(updatedFiles)
-          
-          // Удаляем blob URL из sessionStorage
-          const fileKey = `file_${projectId}_${documentationCode}_${fileToRemove.name}`
-          const blobUrl = sessionStorage.getItem(fileKey)
-          if (blobUrl) {
-            URL.revokeObjectURL(blobUrl)
-            sessionStorage.removeItem(fileKey)
-          }
-          
           message.success(`Файл "${fileToRemove.name}" удален`)
-          console.log(`🗑️ File removed: ${fileToRemove.name}`)
-        } catch (error) {
-          console.error('❌ Error removing file:', error)
+        } catch (err) {
+          console.error('❌ Error removing file:', err)
           message.error('Не удалось удалить файл')
         }
       }
     })
   }
 
-  // Функция для открытия файла в модальном окне
   const openFileInModal = async (file: LocalFile) => {
     try {
-      const fileKey = `file_${projectId}_${documentationCode}_${file.name}`
-      const blobUrl = sessionStorage.getItem(fileKey)
-      
-      if (blobUrl) {
-        const ext = file.extension.toLowerCase()
-        
-        // Проверяем, можно ли открыть файл в браузере
-        if (['pdf', 'xlsx', 'xls', 'docx', 'doc'].includes(ext)) {
-          setPreviewFile(file)
-          setPreviewUrl(blobUrl)
-          setPreviewModalOpen(true)
-          console.log(`👁️ Opening file in modal: ${file.name}`)
-        } else {
-          message.warning(`Файл формата .${ext} нельзя открыть в браузере`)
-        }
+      const url = file.url || onlineFileUrl
+      if (url) {
+        setPreviewFile(file)
+        setPreviewUrl(url)
+        setPreviewModalOpen(true)
       } else {
-        message.error('Файл не найден в текущей сессии. Попробуйте загрузить его снова.')
+        message.error('Ссылка на файл недоступна')
       }
-    } catch (error) {
-      console.error('❌ Error opening file:', error)
+    } catch (err) {
+      console.error('❌ Error opening file:', err)
       message.error('Не удалось открыть файл')
     }
   }
 
-  // Функция для сохранения файла
   const saveFile = (file: LocalFile) => {
-    try {
-      const fileKey = `file_${projectId}_${documentationCode}_${file.name}`
-      const blobUrl = sessionStorage.getItem(fileKey)
-      
-      if (blobUrl) {
-        // Создаем ссылку для скачивания
-        const link = document.createElement('a')
-        link.href = blobUrl
-        link.download = file.name
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
-        
-        message.success(`Файл "${file.name}" сохранен`)
-        console.log(`💾 File saved: ${file.name}`)
-      } else {
-        // Показываем путь к файлу если blob URL не найден
-        modal.info({
-          title: 'Сохранение файла',
-          content: (
-            <div>
-              <p><strong>Файл:</strong> {file.name}</p>
-              <p><strong>Локальный путь:</strong></p>
-              <code style={{ 
-                background: '#f5f5f5', 
-                padding: '4px 8px', 
-                borderRadius: '4px',
-                display: 'block',
-                marginTop: '8px',
-                wordBreak: 'break-all'
-              }}>
-                C:\Users\eugene\WebstormProjects\blueprintflow\{file.path}
-              </code>
-            </div>
-          ),
-          width: 600,
-          okText: 'OK'
-        })
-      }
-    } catch (error) {
-      console.error('❌ Error saving file:', error)
-      message.error('Не удалось сохранить файл')
+    if (file.url) {
+      window.open(file.url, '_blank')
+    } else {
+      message.error('Ссылка на файл недоступна')
     }
   }
 
-  // Создание меню для файла
   const getFileMenuItems = (file: LocalFile): MenuProps['items'] => [
-    {
-      key: 'open',
-      icon: <EyeOutlined />,
-      label: 'Открыть',
-      onClick: () => openFileInModal(file),
-    },
-    {
-      key: 'save',
-      icon: <DownloadOutlined />,
-      label: 'Сохранить',
-      onClick: () => saveFile(file),
-    },
+    { key: 'open', icon: <EyeOutlined />, label: 'Открыть', onClick: () => openFileInModal(file) },
+    { key: 'save', icon: <DownloadOutlined />, label: 'Скачать', onClick: () => saveFile(file) },
+    { key: 'delete', icon: <DeleteOutlined />, danger: true, label: 'Удалить', onClick: () => handleRemoveFile(file) }
   ]
 
   return (
     <div>
-      {/* Файлы и ссылка в одной строке */}
       <Space size={4} align="center">
-        {/* Ссылка на онлайн документ */}
-        {onlineFileUrl && (
-          <Tooltip title={onlineFileUrl}>
-            <Button 
-              type="link" 
-              size="small"
-              onClick={() => window.open(onlineFileUrl, '_blank')}
-              style={{ padding: 0, height: 'auto' }}
-            >
-              Открыть
-            </Button>
-          </Tooltip>
-        )}
-        
-        {/* Список загруженных файлов - только иконки */}
-        {files.map((file, index) => (
-          <Dropdown
-            key={index}
-            menu={{ items: getFileMenuItems(file) }}
-            trigger={['click']}
+        {files.map(file => (
+          <Dropdown key={file.path} menu={{ items: getFileMenuItems(file) }} trigger={['click']}
+            overlayStyle={{ minWidth: 100 }}
           >
-            <Tooltip title={`${file.name} (${(file.size / 1024).toFixed(1)} KB)`}>
-              <div
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  cursor: 'pointer',
-                  position: 'relative'
-                }}
-              >
+            <Tooltip title={file.name}>
+              <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
                 {getFileIcon(file.extension)}
-                {!disabled && (
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<DeleteOutlined />}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      handleRemoveFile(file)
-                    }}
-                    style={{ 
-                      position: 'absolute',
-                      top: -8,
-                      right: -8,
-                      minWidth: 'auto',
-                      width: '16px',
-                      height: '16px',
-                      padding: 0,
-                      display: 'none',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: '10px',
-                      background: 'white',
-                      border: '1px solid #d9d9d9',
-                      borderRadius: '50%'
-                    }}
-                    className="delete-btn"
-                  />
-                )}
+                <Text style={{ marginLeft: 4 }}>{file.name}</Text>
               </div>
             </Tooltip>
           </Dropdown>
         ))}
-        
-        {/* Кнопка добавления файла */}
+
         {!disabled && (
           <Tooltip title="Загрузка файлов pdf, xls/xlsx, doc/docx, dwg">
             <Upload
@@ -319,23 +181,12 @@ export default function FileUpload({ files, onChange, disabled, projectId, docum
               accept=".xlsx,.xls,.docx,.doc,.pdf,.dwg"
               disabled={disabled || uploading}
             >
-              <Button 
-                type="text" 
-                size="small" 
-                icon={<UploadOutlined />} 
-                loading={uploading}
-                style={{ 
-                  padding: '2px 4px',
-                  height: 'auto',
-                  minWidth: 'auto'
-                }}
-              />
+              <Button type="text" size="small" icon={<UploadOutlined />} loading={uploading} />
             </Upload>
           </Tooltip>
         )}
       </Space>
 
-      {/* Модальное окно для предпросмотра */}
       <Modal
         title={previewFile ? `Просмотр: ${previewFile.name}` : 'Просмотр файла'}
         open={previewModalOpen}
@@ -345,67 +196,24 @@ export default function FileUpload({ files, onChange, disabled, projectId, docum
           setPreviewUrl('')
         }}
         width="90%"
-        style={{ maxWidth: '1200px' }}
-        footer={[
-          <Button key="close" onClick={() => {
-            setPreviewModalOpen(false)
-            setPreviewFile(null)
-            setPreviewUrl('')
-          }}>
-            Закрыть
-          </Button>,
-          <Button 
-            key="download" 
-            type="primary" 
-            icon={<DownloadOutlined />}
-            onClick={() => previewFile && saveFile(previewFile)}
-          >
-            Скачать
-          </Button>
-        ]}
+        style={{ maxWidth: 1200 }}
+        footer={null}
       >
         {previewUrl && previewFile && (
           <div style={{ height: '70vh' }}>
             {previewFile.extension.toLowerCase() === 'pdf' ? (
-              <iframe
-                src={previewUrl}
-                style={{ width: '100%', height: '100%', border: 'none' }}
-                title={previewFile.name}
-              />
+              <iframe src={previewUrl} style={{ width: '100%', height: '100%', border: 'none' }} title={previewFile.name} />
             ) : ['xlsx', 'xls', 'docx', 'doc'].includes(previewFile.extension.toLowerCase()) ? (
-              <div style={{ 
-                display: 'flex', 
-                flexDirection: 'column', 
-                alignItems: 'center', 
-                justifyContent: 'center', 
-                height: '100%', 
-                gap: '20px' 
-              }}>
-                <div style={{ fontSize: '48px' }}>
-                  {getFileIcon(previewFile.extension)}
-                </div>
-                <Text style={{ fontSize: '16px' }}>{previewFile.name}</Text>
-                <Text type="secondary">
-                  Размер: {(previewFile.size / 1024 / 1024).toFixed(2)} MB
-                </Text>
-                <Text type="secondary">
-                  Для просмотра файлов Microsoft Office используйте соответствующее приложение
-                </Text>
-                <Button 
-                  type="primary" 
-                  icon={<DownloadOutlined />}
-                  onClick={() => saveFile(previewFile)}
-                >
-                  Скачать и открыть
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 20 }}>
+                <div style={{ fontSize: 48 }}>{getFileIcon(previewFile.extension)}</div>
+                <Text style={{ fontSize: 16 }}>{previewFile.name}</Text>
+                <Text type="secondary">Размер: {(previewFile.size / 1024 / 1024).toFixed(2)} MB</Text>
+                <Button type="primary" icon={<DownloadOutlined />} onClick={() => saveFile(previewFile)}>
+                  Скачать
                 </Button>
               </div>
             ) : (
-              <div style={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                justifyContent: 'center', 
-                height: '100%' 
-              }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
                 <Text>Предпросмотр недоступен для данного типа файла</Text>
               </div>
             )}

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -25,6 +25,8 @@ const pageTitles: Record<string, string> = {
   '/reports': 'Отчёты',
   '/admin': 'Администрирование',
   '/admin/documentation-tags': 'Тэги документации',
+  '/admin/statuses': 'Статусы',
+  '/admin/disk': 'Диск',
 };
 
 const getPageTitle = (path: string): string => {

--- a/src/entities/disk/api/disk-api.ts
+++ b/src/entities/disk/api/disk-api.ts
@@ -1,0 +1,52 @@
+import { supabase } from '@/lib/supabase'
+import type { DiskSettings } from '../types'
+
+export const diskApi = {
+  async getSettings(): Promise<DiskSettings | null> {
+    if (!supabase) throw new Error('Supabase client not initialized')
+
+    const { data, error } = await supabase
+      .from('disk_settings')
+      .select('*')
+      .single()
+
+    if (error && error.code !== 'PGRST116') {
+      console.error('Failed to fetch disk settings:', error)
+      throw error
+    }
+
+    return data as DiskSettings | null
+  },
+
+  async upsertSettings(input: Partial<DiskSettings>): Promise<DiskSettings> {
+    if (!supabase) throw new Error('Supabase client not initialized')
+
+    const { data: existing } = await supabase
+      .from('disk_settings')
+      .select('id')
+      .single()
+
+    const query = supabase.from('disk_settings')
+    const { data, error } = existing
+      ? await query.update(input).eq('id', existing.id).select().single()
+      : await query.insert(input).select().single()
+
+    if (error) {
+      console.error('Failed to upsert disk settings:', error)
+      throw error
+    }
+
+    return data as DiskSettings
+  },
+
+  async fillMappings(): Promise<void> {
+    if (!supabase) throw new Error('Supabase client not initialized')
+
+    const { error } = await supabase.rpc('fill_storage_mappings')
+
+    if (error) {
+      console.error('Failed to fill storage mappings:', error)
+      throw error
+    }
+  }
+}

--- a/src/entities/disk/index.ts
+++ b/src/entities/disk/index.ts
@@ -1,0 +1,2 @@
+export { diskApi } from './api/disk-api'
+export type { DiskSettings } from './types'

--- a/src/entities/disk/types.ts
+++ b/src/entities/disk/types.ts
@@ -1,0 +1,8 @@
+export interface DiskSettings {
+  id: string
+  token: string
+  base_path: string
+  make_public: boolean
+  created_at: string
+  updated_at: string
+}

--- a/src/entities/documentation/api/documentation-api.ts
+++ b/src/entities/documentation/api/documentation-api.ts
@@ -301,6 +301,7 @@ export const documentationApi = {
     versionNumber: number,
     issueDate?: string,
     fileUrl?: string,
+    filePath?: string,
     status: DocumentationVersion['status'] = 'not_filled'
   ) {
     if (!supabase) throw new Error('Supabase client not initialized')
@@ -310,6 +311,7 @@ export const documentationApi = {
       version_number: versionNumber,
       issue_date: issueDate || null,
       file_url: fileUrl || null,
+      file_path: filePath || null,
       status,
     }
     
@@ -337,6 +339,7 @@ export const documentationApi = {
     versionNumber: number,
     issueDate?: string,
     fileUrl?: string,
+    filePath?: string,
     status: DocumentationVersion['status'] = 'not_filled'
   ) {
     if (!supabase) throw new Error('Supabase client not initialized')
@@ -354,6 +357,7 @@ export const documentationApi = {
       version_number: versionNumber,
       issue_date: issueDate || null,
       file_url: fileUrl || null,
+      file_path: filePath || null,
       status,
     }
     
@@ -365,6 +369,7 @@ export const documentationApi = {
         .update({
           issue_date: issueDate || null,
           file_url: fileUrl || null,
+          file_path: filePath || null,
           status,
         })
         .eq('id', existingVersion.id)
@@ -422,7 +427,10 @@ export const documentationApi = {
 
     const { data, error } = await supabase
       .from('documentation_versions')
-      .update({ local_files: localFiles })
+      .update({
+        local_files: localFiles,
+        file_path: localFiles[0]?.path || null,
+      })
       .eq('id', versionId)
       .select()
       .single()
@@ -692,6 +700,7 @@ export const documentationApi = {
     versionNumber?: number
     issueDate?: string
     fileUrl?: string
+    filePath?: string
     status?: DocumentationVersion['status']
     comment?: string
     forceOverwrite?: boolean // Флаг для принудительной перезаписи при конфликте
@@ -721,6 +730,7 @@ export const documentationApi = {
           versionNumber: data.versionNumber,
           issueDate: data.issueDate,
           fileUrl: data.fileUrl,
+          filePath: data.filePath,
           status: data.status || 'not_filled',
           forceOverwrite: data.forceOverwrite
         })
@@ -732,6 +742,7 @@ export const documentationApi = {
             data.versionNumber,
             data.issueDate,
             data.fileUrl,
+            data.filePath,
             data.status || 'not_filled'
           )
           console.log('Version upserted (overwritten):', version)
@@ -742,6 +753,7 @@ export const documentationApi = {
             data.versionNumber,
             data.issueDate,
             data.fileUrl,
+            data.filePath,
             data.status || 'not_filled'
           )
           console.log('Version created:', version)

--- a/src/entities/documentation/types.ts
+++ b/src/entities/documentation/types.ts
@@ -20,6 +20,7 @@ export interface Documentation {
 export interface LocalFile {
   name: string
   path: string
+  url?: string
   size: number
   type: string
   extension: string
@@ -32,6 +33,7 @@ export interface DocumentationVersion {
   version_number: number
   issue_date: string | null
   file_url: string | null
+  file_path: string | null
   local_files: LocalFile[]
   status: 'filled_recalc' | 'filled_spec' | 'not_filled' | 'vor_created'
   created_at: string

--- a/src/lib/transliterate.ts
+++ b/src/lib/transliterate.ts
@@ -1,0 +1,18 @@
+const map: Record<string, string> = {
+  а: 'a', б: 'b', в: 'v', г: 'g', д: 'd', е: 'e', ё: 'e', ж: 'zh', з: 'z', и: 'i',
+  й: 'j', к: 'k', л: 'l', м: 'm', н: 'n', о: 'o', п: 'p', р: 'r', с: 's', т: 't',
+  у: 'u', ф: 'f', х: 'h', ц: 'c', ч: 'ch', ш: 'sh', щ: 'sch', ь: '', ы: 'y', ъ: '',
+  э: 'e', ю: 'yu', я: 'ya'
+}
+
+export function transliterate(value: string): string {
+  return value
+    .split('')
+    .map((char) => {
+      const lower = char.toLowerCase()
+      const mapped = map[lower] || lower
+      return char === lower ? mapped : mapped.charAt(0).toUpperCase() + mapped.slice(1)
+    })
+    .join('')
+    .replace(/[^a-zA-Z0-9]/g, '_')
+}

--- a/src/pages/admin/Disk.tsx
+++ b/src/pages/admin/Disk.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react'
+import { Button, Card, Form, Input, Switch, Typography, message } from 'antd'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { diskApi, type DiskSettings } from '@/entities/disk'
+
+const { Title } = Typography
+
+export default function Disk() {
+  const [form] = Form.useForm<DiskSettings>()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['disk-settings'],
+    queryFn: diskApi.getSettings
+  })
+
+  useEffect(() => {
+    if (data) {
+      form.setFieldsValue(data)
+    }
+  }, [data, form])
+
+  const mutation = useMutation({
+    mutationFn: diskApi.upsertSettings,
+    onSuccess: () => {
+      message.success('Настройки сохранены')
+    },
+    onError: (err) => {
+      console.error('Failed to save settings:', err)
+      message.error('Не удалось сохранить настройки')
+    }
+  })
+
+  const handleFinish = async (values: DiskSettings) => {
+    await mutation.mutateAsync(values)
+  }
+
+  const fillMutation = useMutation({
+    mutationFn: diskApi.fillMappings,
+    onSuccess: () => {
+      message.success('Таблица заполнена')
+    },
+    onError: (err) => {
+      console.error('Failed to fill mappings:', err)
+      message.error('Не удалось заполнить таблицу')
+    }
+  })
+
+  const handleFill = async () => {
+    await fillMutation.mutateAsync()
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Card loading={isLoading}>
+        <div style={{ marginBottom: 16 }}>
+          <Title level={4} style={{ margin: 0 }}>
+            Диск
+          </Title>
+        </div>
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleFinish}
+          autoComplete="off"
+        >
+          <Form.Item
+            label="OAuth токен"
+            name="token"
+            rules={[{ required: true, message: 'Введите токен' }]}
+          >
+            <Input.Password placeholder="Введите токен" />
+          </Form.Item>
+          <Form.Item
+            label="Базовый путь"
+            name="base_path"
+            rules={[{ required: true, message: 'Введите путь' }]}
+          >
+            <Input placeholder="Например, BlueprintFlow" />
+          </Form.Item>
+          <Form.Item label="Публиковать автоматически" name="make_public" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item style={{ textAlign: 'right' }}>
+            <Button type="primary" htmlType="submit" loading={mutation.isPending} style={{ marginRight: 8 }}>
+              Сохранить
+            </Button>
+            <Button onClick={handleFill} loading={fillMutation.isPending}>
+              Заполнить соответствия
+            </Button>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/references/Documentation.tsx
+++ b/src/pages/references/Documentation.tsx
@@ -759,9 +759,6 @@ export default function Documentation() {
             selectedVersion = record.versions.find(v => v.version_number === versionNumber)
           }
 
-          // Получаем проект для создания путей к файлам
-          const project = record.project_id ? { id: record.project_id } : null
-
           return (
             <FileUpload
               files={selectedVersion?.local_files || []}
@@ -769,7 +766,6 @@ export default function Documentation() {
                 if (selectedVersion) {
                   try {
                     await documentationApi.updateVersionLocalFiles(selectedVersion.id, files)
-                    // Перезагружаем данные
                     queryClient.invalidateQueries({ queryKey: ['documentation'] })
                   } catch (error) {
                     console.error('Failed to update files:', error)
@@ -778,7 +774,8 @@ export default function Documentation() {
                 }
               }}
               disabled={false}
-              projectId={project?.id || ''}
+              projectCode={record.project_code}
+              sectionName={record.tag_name}
               documentationCode={record.documentation_id}
               onlineFileUrl={selectedVersion?.file_url || undefined}
             />

--- a/supabase.sql
+++ b/supabase.sql
@@ -117,3 +117,143 @@ on conflict (number) do nothing;
 update chessboard
 set cost_category_code = '99'
 where cost_category_code is null;
+
+-- Настройки Яндекс.Диска
+create table if not exists disk_settings (
+  id uuid primary key default gen_random_uuid(),
+  token text not null,
+  base_path text not null,
+  make_public boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Таблица соответствий для имен в облачном хранилище
+create table if not exists storage_mappings (
+  table_name text not null,
+  entity_id text not null,
+  slug text not null,
+  primary key (table_name, entity_id)
+);
+
+-- Функция транслитерации
+create or replace function transliterate(input text) returns text as $$
+declare
+  result text := '';
+  ch text;
+  mapped text;
+begin
+  for ch in select unnest(regexp_split_to_array(input, '')) loop
+    case lower(ch)
+      when 'а' then mapped := 'a';
+      when 'б' then mapped := 'b';
+      when 'в' then mapped := 'v';
+      when 'г' then mapped := 'g';
+      when 'д' then mapped := 'd';
+      when 'е' then mapped := 'e';
+      when 'ё' then mapped := 'e';
+      when 'ж' then mapped := 'zh';
+      when 'з' then mapped := 'z';
+      when 'и' then mapped := 'i';
+      when 'й' then mapped := 'j';
+      when 'к' then mapped := 'k';
+      when 'л' then mapped := 'l';
+      when 'м' then mapped := 'm';
+      when 'н' then mapped := 'n';
+      when 'о' then mapped := 'o';
+      when 'п' then mapped := 'p';
+      when 'р' then mapped := 'r';
+      when 'с' then mapped := 's';
+      when 'т' then mapped := 't';
+      when 'у' then mapped := 'u';
+      when 'ф' then mapped := 'f';
+      when 'х' then mapped := 'h';
+      when 'ц' then mapped := 'c';
+      when 'ч' then mapped := 'ch';
+      when 'ш' then mapped := 'sh';
+      when 'щ' then mapped := 'sch';
+      when 'ь' then mapped := '';
+      when 'ы' then mapped := 'y';
+      when 'ъ' then mapped := '';
+      when 'э' then mapped := 'e';
+      when 'ю' then mapped := 'yu';
+      when 'я' then mapped := 'ya';
+      else mapped := lower(ch);
+    end case;
+    if ch ~ '[A-Z]' then
+      result := result || upper(left(mapped,1)) || substring(mapped from 2);
+    else
+      result := result || mapped;
+    end if;
+  end loop;
+  return regexp_replace(result, '[^a-zA-Z0-9]', '_', 'g');
+end;
+$$ language plpgsql immutable;
+
+-- Заполнение таблицы соответствий
+create or replace function fill_storage_mappings() returns void as $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'projects', id::text, transliterate(name)
+  from projects
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'documentation_tags', id::text, transliterate(name)
+  from documentation_tags
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'documentation_versions', v.id::text, transliterate(d.code) || '_ver' || v.version_number
+  from documentation_versions v
+  join documentations d on d.id = v.documentation_id
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+end;
+$$ language plpgsql security definer;
+
+-- Триггеры для автоматического заполнения соответствий
+create or replace function trg_storage_projects() returns trigger as $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('projects', new.id::text, transliterate(new.name))
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger storage_projects_after_insert
+after insert on projects
+for each row execute function trg_storage_projects();
+
+create or replace function trg_storage_doc_tags() returns trigger as $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('documentation_tags', new.id::text, transliterate(new.name))
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger storage_doc_tags_after_insert
+after insert on documentation_tags
+for each row execute function trg_storage_doc_tags();
+
+create or replace function trg_storage_doc_versions() returns trigger as $$
+declare
+  doc_code text;
+begin
+  select code into doc_code from documentations where id = new.documentation_id;
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('documentation_versions', new.id::text, transliterate(doc_code) || '_ver' || new.version_number)
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger storage_doc_versions_after_insert
+after insert on documentation_versions
+for each row execute function trg_storage_doc_versions();
+
+-- Добавление пути к файлу в версии документации
+alter table if exists documentation_versions
+  add column if not exists file_path text;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -8643,6 +8643,160 @@ GRANT ALL ON TABLE public.documentation_versions TO anon;
 GRANT ALL ON TABLE public.documentation_versions TO authenticated;
 GRANT ALL ON TABLE public.documentation_versions TO service_role;
 
+-- Настройки Яндекс.Диска
+CREATE TABLE IF NOT EXISTS public.disk_settings (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token text NOT NULL,
+    base_path text NOT NULL,
+    make_public boolean DEFAULT true,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
+);
+
+-- Таблица соответствий для имен в облачном хранилище
+CREATE TABLE IF NOT EXISTS public.storage_mappings (
+    table_name text NOT NULL,
+    entity_id text NOT NULL,
+    slug text NOT NULL,
+    CONSTRAINT storage_mappings_pkey PRIMARY KEY (table_name, entity_id)
+);
+
+CREATE OR REPLACE FUNCTION public.transliterate(input text)
+ RETURNS text
+ LANGUAGE plpgsql
+ IMMUTABLE
+AS $$
+declare
+  result text := '';
+  ch text;
+  mapped text;
+begin
+  for ch in select unnest(regexp_split_to_array(input, '')) loop
+    case lower(ch)
+      when 'а' then mapped := 'a';
+      when 'б' then mapped := 'b';
+      when 'в' then mapped := 'v';
+      when 'г' then mapped := 'g';
+      when 'д' then mapped := 'd';
+      when 'е' then mapped := 'e';
+      when 'ё' then mapped := 'e';
+      when 'ж' then mapped := 'zh';
+      when 'з' then mapped := 'z';
+      when 'и' then mapped := 'i';
+      when 'й' then mapped := 'j';
+      when 'к' then mapped := 'k';
+      when 'л' then mapped := 'l';
+      when 'м' then mapped := 'm';
+      when 'н' then mapped := 'n';
+      when 'о' then mapped := 'o';
+      when 'п' then mapped := 'p';
+      when 'р' then mapped := 'r';
+      when 'с' then mapped := 's';
+      when 'т' then mapped := 't';
+      when 'у' then mapped := 'u';
+      when 'ф' then mapped := 'f';
+      when 'х' then mapped := 'h';
+      when 'ц' then mapped := 'c';
+      when 'ч' then mapped := 'ch';
+      when 'ш' then mapped := 'sh';
+      when 'щ' then mapped := 'sch';
+      when 'ь' then mapped := '';
+      when 'ы' then mapped := 'y';
+      when 'ъ' then mapped := '';
+      when 'э' then mapped := 'e';
+      when 'ю' then mapped := 'yu';
+      when 'я' then mapped := 'ya';
+      else mapped := lower(ch);
+    end case;
+    if ch ~ '[A-Z]' then
+      result := result || upper(left(mapped,1)) || substring(mapped from 2);
+    else
+      result := result || mapped;
+    end if;
+  end loop;
+  return regexp_replace(result, '[^a-zA-Z0-9]', '_', 'g');
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fill_storage_mappings()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'projects', id::text, public.transliterate(name)
+  from public.projects
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'documentation_tags', id::text, public.transliterate(name)
+  from public.documentation_tags
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+
+  insert into storage_mappings(table_name, entity_id, slug)
+  select 'documentation_versions', v.id::text, public.transliterate(d.code) || '_ver' || v.version_number
+  from public.documentation_versions v
+  join public.documentations d on d.id = v.documentation_id
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.trg_storage_projects()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('projects', new.id::text, public.transliterate(new.name))
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$;
+
+CREATE TRIGGER storage_projects_after_insert
+AFTER INSERT ON public.projects
+FOR EACH ROW EXECUTE FUNCTION public.trg_storage_projects();
+
+CREATE OR REPLACE FUNCTION public.trg_storage_doc_tags()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $$
+begin
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('documentation_tags', new.id::text, public.transliterate(new.name))
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$;
+
+CREATE TRIGGER storage_doc_tags_after_insert
+AFTER INSERT ON public.documentation_tags
+FOR EACH ROW EXECUTE FUNCTION public.trg_storage_doc_tags();
+
+CREATE OR REPLACE FUNCTION public.trg_storage_doc_versions()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $$
+declare
+  doc_code text;
+begin
+  select code into doc_code from public.documentations where id = new.documentation_id;
+  insert into storage_mappings(table_name, entity_id, slug)
+  values ('documentation_versions', new.id::text, public.transliterate(doc_code) || '_ver' || new.version_number)
+  on conflict (table_name, entity_id) do update set slug = excluded.slug;
+  return new;
+end;
+$$;
+
+CREATE TRIGGER storage_doc_versions_after_insert
+AFTER INSERT ON public.documentation_versions
+FOR EACH ROW EXECUTE FUNCTION public.trg_storage_doc_versions();
+
+-- Добавление пути к файлу в версии документации
+ALTER TABLE IF EXISTS public.documentation_versions
+    ADD COLUMN IF NOT EXISTS file_path text;
+
 
 --
 -- Name: TABLE documentations; Type: ACL; Schema: public; Owner: postgres


### PR DESCRIPTION
## Summary
- upload documentation files to Yandex Disk and keep public links
- add admin page for Yandex Disk settings
- store cloud paths in documentation versions and add storage mapping tables
- add triggers and sync for storage mappings

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build` *(fails: Property 'children' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68adce01ed20832e8202ca92df379893