### PR TITLE
fix: show documentation file link and icons

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -329,14 +329,27 @@ export default function FileUpload({ files, onChange, disabled, projectName, sec
   return (
     <div>
       <Space size={4} align="center">
+        {onlineFileUrl && (
+          <a
+            href={onlineFileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ marginRight: 4 }}
+          >
+            Открыть
+          </a>
+        )}
+
         {files.map(file => (
-          <Dropdown key={file.path} menu={{ items: getFileMenuItems(file) }} trigger={['click']}
+          <Dropdown
+            key={file.path}
+            menu={{ items: getFileMenuItems(file) }}
+            trigger={['click']}
             overlayStyle={{ minWidth: 100 }}
           >
             <Tooltip title={file.name}>
               <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
                 {getFileIcon(file.extension)}
-                <Text style={{ marginLeft: 4 }}>{file.name}</Text>
               </div>
             </Tooltip>
           </Dropdown>


### PR DESCRIPTION
## Summary
- show "Open" link for documentation files and display attached file icons without names

## Testing
- `npm run lint` *(fails: Unexpected any / unused vars)*
- `npm run build` *(fails: TS errors in documents/Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68af04b2c5ac832e95088b88bcdee082