### PR TITLE
fix: avoid 404 errors from Yandex Disk API during file upload

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -57,24 +57,31 @@ const ensureFolderPath = async (folderPath: string, token: string): Promise<void
   let current = segments[0]
   for (let i = 1; i < segments.length; i++) {
     current = `${current}/${segments[i]}`
-    const check = await fetch(
+    const res = await fetch(
       `https://cloud-api.yandex.net/v1/disk/resources?path=${encodeURIComponent(current)}`,
-      { headers: { Authorization: `OAuth ${token}` } }
+      { method: 'PUT', headers: { Authorization: `OAuth ${token}` } }
     )
-    if (check.status === 404) {
-      const createRes = await fetch(
-        `https://cloud-api.yandex.net/v1/disk/resources?path=${encodeURIComponent(current)}`,
-        { method: 'PUT', headers: { Authorization: `OAuth ${token}` } }
-      )
-      if (!createRes.ok && createRes.status !== 409) {
-        const errorText = await createRes.text()
-        throw new Error(`Failed to create folder ${current}: ${createRes.status} ${errorText}`)
-      }
-    } else if (!check.ok) {
-      const errorText = await check.text()
-      throw new Error(`Failed to check folder ${current}: ${check.status} ${errorText}`)
+    if (!res.ok && res.status !== 409) {
+      const errorText = await res.text()
+      throw new Error(`Failed to create folder ${current}: ${res.status} ${errorText}`)
     }
   }
+}
+
+const fileExists = async (filePath: string, token: string): Promise<boolean> => {
+  const folder = filePath.substring(0, filePath.lastIndexOf('/'))
+  const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+  const res = await fetch(
+    `https://cloud-api.yandex.net/v1/disk/resources?path=${encodeURIComponent(folder)}&limit=1000&fields=_embedded.items.name`,
+    { headers: { Authorization: `OAuth ${token}` } }
+  )
+  if (!res.ok) {
+    const errorText = await res.text()
+    throw new Error(`Failed to list folder ${folder}: ${res.status} ${errorText}`)
+  }
+  const data = await res.json()
+  const items = data?._embedded?.items ?? []
+  return items.some((item: { name: string }) => item.name === fileName)
 }
 
 const buildFilePaths = (
@@ -185,10 +192,7 @@ export default function FileUpload({ files, onChange, disabled, projectName, sec
 
       await ensureFolderPath(folderPath, settings.token)
 
-      const checkRes = await fetch(
-        `https://cloud-api.yandex.net/v1/disk/resources?path=${encodeURIComponent(filePath)}`,
-        { headers: { Authorization: `OAuth ${settings.token}` } }
-      )
+      const exists = await fileExists(filePath, settings.token)
 
       const doUpload = async () => {
         setUploading(true)
@@ -222,7 +226,7 @@ export default function FileUpload({ files, onChange, disabled, projectName, sec
         }
       }
 
-      if (checkRes.ok) {
+      if (exists) {
         setUploading(false)
         modal.confirm({
           title: 'Файл уже существует',
@@ -234,11 +238,8 @@ export default function FileUpload({ files, onChange, disabled, projectName, sec
             onError?.(new Error('Upload cancelled'))
           },
         })
-      } else if (checkRes.status === 404) {
-        await doUpload()
       } else {
-        const errorText = await checkRes.text()
-        throw new Error(`Failed to check file existence: ${checkRes.status} ${errorText}`)
+        await doUpload()
       }
     } catch (e) {
       console.error('❌ Error uploading file:', e)


### PR DESCRIPTION
## Summary
- avoid Yandex Disk 404 errors by creating folders directly
- check existing files via folder listing to prevent console errors

## Testing
- `npm run lint` *(fails: _color is defined but never used and many other @typescript-eslint/no-explicit-any errors)*
- `npm run build` *(fails: Property 'children' does not exist on type... and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af074e6244832e92d5f006837bcd99