### PR TITLE
feat: add portal logo above menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import Statuses from './pages/admin/Statuses'
 import Disk from './pages/admin/Disk'
 import PortalHeader from './components/PortalHeader'
 import TestTableStructure from './pages/TestTableStructure'
+import logoLight from './logo_light.svg'
 
 const { Sider, Content } = Layout
 
@@ -441,7 +442,14 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           collapsed={collapsed}
           onCollapse={setCollapsed}
         >
-          <div style={{ height: 64 }} />
+          <div
+            style={{
+              width: '100%',
+              marginBottom: 16,
+            }}
+          >
+            <img src={logoLight} alt="BlueprintFlow logo" style={{ width: '100%', height: 'auto', display: 'block' }} />
+          </div>
           <Menu
             theme={isDark ? 'dark' : 'light'}
             mode="inline"

--- a/src/logo_light.svg
+++ b/src/logo_light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <text x="0" y="28" font-size="28" font-family="Arial, sans-serif" fill="#1890ff">BlueprintFlow</text>
+</svg>


### PR DESCRIPTION
## Summary
- show BlueprintFlow logo above the side menu
- include SVG logo asset

## Testing
- `npm run lint` (fails: no-unused-vars, no-explicit-any, etc.)
- `npm run build` (fails: TS2339/TS17001)


------
https://chatgpt.com/codex/tasks/task_e_68af0e683b78832eb54e1ae3ad422958