### PR TITLE
fix: correct rates page header

### DIFF
--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -18,6 +18,7 @@ const pageTitles: Record<string, string> = {
   '/library/rd-codes': 'Шифры РД',
   '/library/pd-codes': 'Шифры ПД',
   '/references': 'Единицы измерения',
+  '/references/rates': 'Расценки',
   '/documents/documentation': 'Документация',
   '/references/cost-categories': 'Категории затрат',
   '/references/projects': 'Проекты',


### PR DESCRIPTION
## Summary
- display "Расценки" for /references/rates in portal header

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm run build` *(fails: JSX elements cannot have multiple attributes in src/pages/documents/Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68af13c66bac832eb2e338475067b5e3