### PR TITLE
fix: show all locations for selected cost type

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1414,11 +1414,17 @@ export default function Chessboard() {
                       if (record.costTypeId) {
                         const selectedType = costTypes?.find((t) => String(t.id) === record.costTypeId)
                         if (selectedType) {
-                          // Находим все виды затрат с таким же названием
-                          const sameNameTypes = costTypes?.filter((t) => t.name === selectedType.name)
-                          // Получаем все location_id для этих видов затрат
-                          const availableLocationIds = sameNameTypes?.map((t) => String(t.location_id))
-                          return availableLocationIds?.includes(String(l.id))
+                          // Находим все виды затрат с таким же названием и категорией
+                          const sameNameTypes = costTypes?.filter(
+                            (t) =>
+                              t.name === selectedType.name &&
+                              t.cost_category_id === selectedType.cost_category_id,
+                          )
+                          // Получаем уникальные location_id для этих видов затрат
+                          const availableLocationIds = new Set(
+                            sameNameTypes?.map((t) => String(t.location_id)) || [],
+                          )
+                          return availableLocationIds.has(String(l.id))
                         }
                       }
                       // Если вид затрат не выбран, показываем все локализации
@@ -1801,11 +1807,17 @@ export default function Chessboard() {
                       if (edit.costTypeId) {
                         const selectedType = costTypes?.find((t) => String(t.id) === edit.costTypeId)
                         if (selectedType) {
-                          // Находим все виды затрат с таким же названием
-                          const sameNameTypes = costTypes?.filter((t) => t.name === selectedType.name)
-                          // Получаем все location_id для этих видов затрат
-                          const availableLocationIds = sameNameTypes?.map((t) => String(t.location_id))
-                          return availableLocationIds?.includes(String(l.id))
+                          // Находим все виды затрат с таким же названием и категорией
+                          const sameNameTypes = costTypes?.filter(
+                            (t) =>
+                              t.name === selectedType.name &&
+                              t.cost_category_id === selectedType.cost_category_id,
+                          )
+                          // Получаем уникальные location_id для этих видов затрат
+                          const availableLocationIds = new Set(
+                            sameNameTypes?.map((t) => String(t.location_id)) || [],
+                          )
+                          return availableLocationIds.has(String(l.id))
                         }
                       }
                       // Если вид затрат не выбран, показываем все локализации


### PR DESCRIPTION
## Summary
- allow selecting all available locations for a chosen cost type on chessboard page

## Testing
- `npm run lint` *(fails: Unexpected any, etc. in unrelated files)*
- `npm run build` *(fails: TypeScript errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68af22f32c5c832ea93604e91c6b4b75