### PR TITLE
fix: update chessboard button colors

### DIFF
--- a/src/pages/documents/Chessboard.css
+++ b/src/pages/documents/Chessboard.css
@@ -1,0 +1,18 @@
+.chessboard-page .apply-btn,
+.chessboard-page .add-btn {
+  background-color: #b2a4d0;
+  border-color: #b2a4d0;
+  color: #fff;
+}
+
+.chessboard-page .apply-btn:hover,
+.chessboard-page .add-btn:hover {
+  background-color: #b2a4d0;
+  border-color: #b2a4d0;
+  color: #fff;
+}
+
+.chessboard-page .ant-btn:hover:not(.apply-btn):not(.add-btn) {
+  color: #b2a4d0;
+  border-color: #b2a4d0;
+}

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -7,6 +7,7 @@ import * as XLSX from 'xlsx'
 import { supabase } from '../../lib/supabase'
 import { documentationApi } from '@/entities/documentation'
 import { documentationTagsApi } from '@/entities/documentation-tags'
+import './Chessboard.css'
 
 type RowColor = '' | 'green' | 'yellow' | 'blue' | 'red'
 
@@ -2169,9 +2170,9 @@ export default function Chessboard() {
   }, [viewRows, allColumns])
 
   return (
-    <div style={{ 
-      height: 'calc(100vh - 96px)', 
-      display: 'flex', 
+    <div className="chessboard-page" style={{
+      height: 'calc(100vh - 96px)',
+      display: 'flex',
       flexDirection: 'column',
       overflow: 'hidden',
       position: 'relative'
@@ -2224,11 +2225,12 @@ export default function Chessboard() {
                 return false
               }}
             />
-            <Button 
-              type="primary" 
+            <Button
+              type="primary"
               size="large"
-              onClick={handleApply} 
+              onClick={handleApply}
               disabled={!filters.projectId}
+              className="apply-btn"
             >
               Применить
             </Button>
@@ -2267,6 +2269,7 @@ export default function Chessboard() {
                 type="primary"
                 icon={<PlusOutlined />}
                 onClick={startAdd}
+                className="add-btn"
               >
                 Добавить
               </Button>


### PR DESCRIPTION
## Summary
- adjust Chessboard page styles so Apply and Add buttons use #b2a4d0
- change other button hover styles to use #b2a4d0 outline and text

## Testing
- `npm run lint` *(fails: '_color' is defined but never used ...)*
- `npm run build` *(fails: Property 'children' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68af2a9e218c832e9820f2c8fa8b515f