### PR TITLE
feat: update header and theme colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,7 +434,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
       </style>
       <Layout style={{ minHeight: '100vh' }}>
         <Sider
-          theme={isDark ? 'dark' : 'light'}
+          theme="light"
           style={{
             background: 'var(--menu-bg)',
           }}
@@ -458,7 +458,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             />
           </div>
           <Menu
-            theme={isDark ? 'dark' : 'light'}
+            theme="light"
             mode="inline"
             inlineCollapsed={collapsed}
             items={items}
@@ -483,7 +483,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           />
         </Sider>
         <Layout>
-          <PortalHeader isDark={isDark} />
+          <PortalHeader />
           <Content
             style={{
               margin: 16,

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -37,11 +37,7 @@ const getPageTitle = (path: string): string => {
   return matched ? pageTitles[matched] : '';
 };
 
-interface PortalHeaderProps {
-  isDark: boolean;
-}
-
-export default function PortalHeader({ isDark }: PortalHeaderProps) {
+export default function PortalHeader() {
   const { pathname } = useLocation();
   const [userEmail, setUserEmail] = useState<string>('');
 
@@ -55,12 +51,12 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
   return (
     <Header
       style={{
-        background: isDark ? '#555555' : '#EEF0F1',
+        background: '#D8BFD8',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        color: isDark ? '#ffffff' : '#000000',
+        color: '#000000',
       }}
     >
         <div style={{ fontSize: '16px', fontWeight: 500 }}>

--- a/src/index.css
+++ b/src/index.css
@@ -6,13 +6,13 @@ body {
 }
 
 body[data-theme='light'] {
-  --menu-bg: #EEF0F1;
+  --menu-bg: #D8BFD8;
   --menu-color: #000000;
 }
 
 body[data-theme='dark'] {
-  --menu-bg: #555555;
-  --menu-color: #ffffff;
+  --menu-bg: #D8BFD8;
+  --menu-color: #000000;
 }
 
 .ant-menu-dark,

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -37,15 +37,15 @@ const items: MenuProps['items'] = [
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
-  const isDark = true;
   const [collapsed, setCollapsed] = useState(false);
   const siderWidth = collapsed ? 80 : 200;
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider 
-        theme="dark" 
-        style={{ 
-          background: '#333333',
+      <Sider
+        theme="light"
+        style={{
+          background: '#D8BFD8',
+          color: '#000000',
           position: 'fixed',
           left: 0,
           top: 0,
@@ -59,29 +59,29 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       >
         <div style={{ height: 64 }} />
         <Menu
-          theme="dark"
+          theme="light"
           mode="inline"
           selectedKeys={[location.pathname]}
           items={items}
-          style={{ background: '#333333' }}
+          style={{ background: '#D8BFD8' }}
         />
       </Sider>
       <Layout style={{ marginLeft: siderWidth, transition: 'margin-left 0.2s' }}>
-        <div style={{ 
-          position: 'fixed', 
-          top: 0, 
-          right: 0, 
-          left: siderWidth, 
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          left: siderWidth,
           zIndex: 99,
-          background: '#333333',
+          background: '#D8BFD8',
           transition: 'left 0.2s'
         }}>
-          <PortalHeader isDark={isDark} />
+          <PortalHeader />
         </div>
-        <Content style={{ 
-          marginTop: 64, 
-          padding: '16px', 
-          background: '#333333', 
+        <Content style={{
+          marginTop: 64,
+          padding: '16px',
+          background: '#333333',
           color: '#ffffff',
           minHeight: 'calc(100vh - 64px)'
         }}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,26 +34,28 @@ export function Root() {
     <ConfigProvider
       theme={
         isDark
-          ? {
-              algorithm: theme.darkAlgorithm,
-              token: {
-                colorPrimary: '#ffffff',
-                colorBgLayout: '#555555',
-                colorBgContainer: '#555555',
-                colorText: '#ffffff',
-              },
-            }
-          : {
-              algorithm: theme.defaultAlgorithm,
-              token: {
-                colorPrimary: '#0000ff',
-                colorBgLayout: '#FCFCFC',
-                colorBgContainer: '#FCFCFC',
-                colorText: '#000000',
-              },
-            }
-      }
-    >
+            ? {
+                algorithm: theme.darkAlgorithm,
+                token: {
+                  colorPrimary: '#DA70D6',
+                  colorPrimaryHover: '#DA70D6',
+                  colorBgLayout: '#555555',
+                  colorBgContainer: '#555555',
+                  colorText: '#ffffff',
+                },
+              }
+            : {
+                algorithm: theme.defaultAlgorithm,
+                token: {
+                  colorPrimary: '#DA70D6',
+                  colorPrimaryHover: '#DA70D6',
+                  colorBgLayout: '#FCFCFC',
+                  colorBgContainer: '#FCFCFC',
+                  colorText: '#000000',
+                },
+              }
+        }
+      >
       <AntdApp>
         <QueryClientProvider client={queryClient}>
           <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>


### PR DESCRIPTION
## Summary
- recolor portal header and side menu to lavender theme
- switch Ant Design primary color to purple

## Testing
- `npm run lint` *(fails: '_color' is defined but never used ...)*
- `npm run build` *(fails: Property 'children' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aff5e8df34832eb1ddd7f49d749856