### PR TITLE
Обновление цветовой схемы портала

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,15 +69,15 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             width: 32,
             height: 32,
             borderRadius: 4,
-            border: `1px solid ${isActive 
-              ? '#1890ff'
+            border: `1px solid ${isActive
+              ? '#c3b8cc'
               : 'transparent'}`,
             boxShadow: 'none',
             backgroundColor: isActive
-              ? isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'
+              ? isDark ? 'rgba(195, 184, 204, 0.1)' : 'rgba(195, 184, 204, 0.05)'
               : 'transparent',
-            color: isActive 
-              ? '#1890ff'
+            color: isActive
+              ? '#c3b8cc'
               : isDark ? '#ffffff' : '#000000',
             display: 'flex',
             alignItems: 'center',
@@ -353,29 +353,29 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             border: none !important;
             border-radius: 0 !important;
             box-shadow: none !important;
-            color: #1890ff !important;
+            color: #c3b8cc !important;
             margin: 0 !important;
           }
-          
+
           .ant-menu-item-selected a {
-            color: #1890ff !important;
+            color: #c3b8cc !important;
           }
-          
+
           .ant-menu-submenu .ant-menu-item-selected {
-            background-color: ${isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'} !important;
-            border: 1px solid #1890ff !important;
+            background-color: ${isDark ? 'rgba(195, 184, 204, 0.1)' : 'rgba(195, 184, 204, 0.05)'} !important;
+            border: 1px solid #c3b8cc !important;
             border-radius: 4px !important;
             box-shadow: none !important;
-            color: #1890ff !important;
+            color: #c3b8cc !important;
             margin: 2px 8px !important;
           }
-          
+
           .ant-menu-submenu .ant-menu-item-selected a {
-            color: #1890ff !important;
+            color: #c3b8cc !important;
           }
-          
+
           .ant-menu-submenu-selected > .ant-menu-submenu-title {
-            color: #1890ff !important;
+            color: #c3b8cc !important;
           }
           
           .ant-menu-item:hover:not(.ant-menu-item-selected) {

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -55,7 +55,7 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
   return (
     <Header
       style={{
-        background: isDark ? '#555555' : '#EEF0F1',
+        background: isDark ? '#555555' : '#eee9f2',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/entities/documentation/types.ts
+++ b/src/entities/documentation/types.ts
@@ -136,7 +136,7 @@ export const STATUS_COLORS = {
   filled_recalc: '#52c41a', // green
   filled_spec: '#faad14', // yellow
   not_filled: '#ff4d4f', // red
-  vor_created: '#1890ff', // blue
+  vor_created: '#c3b8cc', // blue
 } as const
 
 export const STATUS_LABELS = {

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@ body {
 }
 
 body[data-theme='light'] {
-  --menu-bg: #EEF0F1;
+  --menu-bg: #eee9f2;
   --menu-color: #000000;
 }
 

--- a/src/logo_light.svg
+++ b/src/logo_light.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
-  <text x="0" y="28" font-size="28" font-family="Arial, sans-serif" fill="#1890ff">BlueprintFlow</text>
+  <text x="0" y="28" font-size="28" font-family="Arial, sans-serif" fill="#c3b8cc">BlueprintFlow</text>
 </svg>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,7 @@ export function Root() {
           ? {
               algorithm: theme.darkAlgorithm,
               token: {
-                colorPrimary: '#ffffff',
+                colorPrimary: '#c3b8cc',
                 colorBgLayout: '#555555',
                 colorBgContainer: '#555555',
                 colorText: '#ffffff',
@@ -46,7 +46,7 @@ export function Root() {
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#0000ff',
+                colorPrimary: '#c3b8cc',
                 colorBgLayout: '#FCFCFC',
                 colorBgContainer: '#FCFCFC',
                 colorText: '#000000',

--- a/src/pages/admin/Statuses.tsx
+++ b/src/pages/admin/Statuses.tsx
@@ -20,7 +20,7 @@ const colorOptions = [
   { label: 'Зеленый', value: 'green', color: '#52c41a' },
   { label: 'Желтый', value: 'yellow', color: '#faad14' },
   { label: 'Красный', value: 'red', color: '#ff4d4f' },
-  { label: 'Синий', value: 'blue', color: '#1890ff' },
+  { label: 'Синий', value: 'blue', color: '#c3b8cc' },
 ]
 
 export default function Statuses() {

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2242,9 +2242,9 @@ export default function Chessboard() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
+                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#c3b8cc' : undefined }} />
+                    {filtersExpanded ?
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#c3b8cc' }} /> :
                       <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>
@@ -2254,7 +2254,7 @@ export default function Chessboard() {
                   padding: '4px 12px',
                   display: 'flex',
                   alignItems: 'center',
-                  borderColor: filtersExpanded ? '#1890ff' : undefined
+                  borderColor: filtersExpanded ? '#c3b8cc' : undefined
                 }}
               >
                 Фильтры

--- a/src/pages/references/Documentation.tsx
+++ b/src/pages/references/Documentation.tsx
@@ -1507,9 +1507,9 @@ export default function Documentation() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
+                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#c3b8cc' : undefined }} />
+                    {filtersExpanded ?
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#c3b8cc' }} /> :
                       <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>


### PR DESCRIPTION
## Summary
- изменить цвет шапки и меню на `#eee9f2`
- заменить синий акцент интерфейса на `#c3b8cc`

## Testing
- `npm run lint` (failed: Unexpected any, etc.)
- `npm run build` (failed: TS17001 multiple attributes, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68aff8fa3cdc832ead10b34b77058bdf