### PR TITLE
style: update color palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,15 +69,15 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             width: 32,
             height: 32,
             borderRadius: 4,
-            border: `1px solid ${isActive 
-              ? '#1890ff'
+            border: `1px solid ${isActive
+              ? '#a798b3'
               : 'transparent'}`,
             boxShadow: 'none',
             backgroundColor: isActive
-              ? isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'
+              ? isDark ? 'rgba(167, 152, 179, 0.1)' : 'rgba(167, 152, 179, 0.05)'
               : 'transparent',
-            color: isActive 
-              ? '#1890ff'
+            color: isActive
+              ? '#a798b3'
               : isDark ? '#ffffff' : '#000000',
             display: 'flex',
             alignItems: 'center',
@@ -353,29 +353,29 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             border: none !important;
             border-radius: 0 !important;
             box-shadow: none !important;
-            color: #1890ff !important;
+            color: #a798b3 !important;
             margin: 0 !important;
           }
-          
+
           .ant-menu-item-selected a {
-            color: #1890ff !important;
+            color: #a798b3 !important;
           }
-          
+
           .ant-menu-submenu .ant-menu-item-selected {
-            background-color: ${isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'} !important;
-            border: 1px solid #1890ff !important;
+            background-color: ${isDark ? 'rgba(167, 152, 179, 0.1)' : 'rgba(167, 152, 179, 0.05)'} !important;
+            border: 1px solid #a798b3 !important;
             border-radius: 4px !important;
             box-shadow: none !important;
-            color: #1890ff !important;
+            color: #a798b3 !important;
             margin: 2px 8px !important;
           }
-          
+
           .ant-menu-submenu .ant-menu-item-selected a {
-            color: #1890ff !important;
+            color: #a798b3 !important;
           }
-          
+
           .ant-menu-submenu-selected > .ant-menu-submenu-title {
-            color: #1890ff !important;
+            color: #a798b3 !important;
           }
           
           .ant-menu-item:hover:not(.ant-menu-item-selected) {

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -55,7 +55,7 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
   return (
     <Header
       style={{
-        background: isDark ? '#555555' : '#EEF0F1',
+        background: isDark ? '#555555' : '#efebf2',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@ body {
 }
 
 body[data-theme='light'] {
-  --menu-bg: #EEF0F1;
+  --menu-bg: #efebf2;
   --menu-color: #000000;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,7 +46,7 @@ export function Root() {
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#0000ff',
+                colorPrimary: '#a798b3',
                 colorBgLayout: '#FCFCFC',
                 colorBgContainer: '#FCFCFC',
                 colorText: '#000000',

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2242,9 +2242,9 @@ export default function Chessboard() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
+                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a798b3' : undefined }} />
+                    {filtersExpanded ?
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#a798b3' }} /> :
                       <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>
@@ -2254,7 +2254,7 @@ export default function Chessboard() {
                   padding: '4px 12px',
                   display: 'flex',
                   alignItems: 'center',
-                  borderColor: filtersExpanded ? '#1890ff' : undefined
+                  borderColor: filtersExpanded ? '#a798b3' : undefined
                 }}
               >
                 Фильтры

--- a/src/pages/references/Documentation.tsx
+++ b/src/pages/references/Documentation.tsx
@@ -1507,9 +1507,9 @@ export default function Documentation() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
+                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a798b3' : undefined }} />
+                    {filtersExpanded ?
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#a798b3' }} /> :
                       <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>


### PR DESCRIPTION
## Summary
- change header and menu color to #efebf2
- replace blue accents with #a798b3 and update Ant Design primary color

## Testing
- `npm run lint` (fails: _color is defined but never used)
- `npm run build` (fails: Property 'children' does not exist on type)


------
https://chatgpt.com/codex/tasks/task_e_68affb98c200832e8770fe0afb5c0ea4