### PR TITLE
feat: update portal color palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,16 +69,16 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             width: 32,
             height: 32,
             borderRadius: 4,
-            border: `1px solid ${isActive 
-              ? '#1890ff'
-              : 'transparent'}`,
+              border: `1px solid ${isActive
+                ? '#a69ead'
+                : 'transparent'}`,
             boxShadow: 'none',
             backgroundColor: isActive
-              ? isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'
+              ? isDark ? 'rgba(166, 158, 173, 0.1)' : 'rgba(166, 158, 173, 0.05)'
               : 'transparent',
-            color: isActive 
-              ? '#1890ff'
-              : isDark ? '#ffffff' : '#000000',
+              color: isActive
+                ? '#a69ead'
+                : isDark ? '#ffffff' : '#000000',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -348,35 +348,35 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
     <>
       <style>
         {`
-          .ant-menu-item-selected {
-            background-color: transparent !important;
-            border: none !important;
-            border-radius: 0 !important;
-            box-shadow: none !important;
-            color: #1890ff !important;
-            margin: 0 !important;
-          }
-          
-          .ant-menu-item-selected a {
-            color: #1890ff !important;
-          }
-          
-          .ant-menu-submenu .ant-menu-item-selected {
-            background-color: ${isDark ? 'rgba(24, 144, 255, 0.1)' : 'rgba(24, 144, 255, 0.05)'} !important;
-            border: 1px solid #1890ff !important;
-            border-radius: 4px !important;
-            box-shadow: none !important;
-            color: #1890ff !important;
-            margin: 2px 8px !important;
-          }
-          
-          .ant-menu-submenu .ant-menu-item-selected a {
-            color: #1890ff !important;
-          }
-          
-          .ant-menu-submenu-selected > .ant-menu-submenu-title {
-            color: #1890ff !important;
-          }
+            .ant-menu-item-selected {
+              background-color: transparent !important;
+              border: none !important;
+              border-radius: 0 !important;
+              box-shadow: none !important;
+              color: #a69ead !important;
+              margin: 0 !important;
+            }
+
+            .ant-menu-item-selected a {
+              color: #a69ead !important;
+            }
+
+            .ant-menu-submenu .ant-menu-item-selected {
+              background-color: ${isDark ? 'rgba(166, 158, 173, 0.1)' : 'rgba(166, 158, 173, 0.05)'} !important;
+              border: 1px solid #a69ead !important;
+              border-radius: 4px !important;
+              box-shadow: none !important;
+              color: #a69ead !important;
+              margin: 2px 8px !important;
+            }
+
+            .ant-menu-submenu .ant-menu-item-selected a {
+              color: #a69ead !important;
+            }
+
+            .ant-menu-submenu-selected > .ant-menu-submenu-title {
+              color: #a69ead !important;
+            }
           
           .ant-menu-item:hover:not(.ant-menu-item-selected) {
             background-color: ${isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'} !important;

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -55,7 +55,7 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
   return (
     <Header
       style={{
-        background: isDark ? '#555555' : '#EEF0F1',
+        background: isDark ? '#555555' : '#f0edf2',
         padding: '0 16px',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@ body {
 }
 
 body[data-theme='light'] {
-  --menu-bg: #EEF0F1;
+  --menu-bg: #f0edf2;
   --menu-color: #000000;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,9 @@ export function Root() {
           ? {
               algorithm: theme.darkAlgorithm,
               token: {
-                colorPrimary: '#ffffff',
+                colorPrimary: '#a69ead',
+                colorInfo: '#a69ead',
+                colorLink: '#a69ead',
                 colorBgLayout: '#555555',
                 colorBgContainer: '#555555',
                 colorText: '#ffffff',
@@ -46,7 +48,9 @@ export function Root() {
           : {
               algorithm: theme.defaultAlgorithm,
               token: {
-                colorPrimary: '#0000ff',
+                colorPrimary: '#a69ead',
+                colorInfo: '#a69ead',
+                colorLink: '#a69ead',
                 colorBgLayout: '#FCFCFC',
                 colorBgContainer: '#FCFCFC',
                 colorText: '#000000',

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2242,10 +2242,10 @@ export default function Chessboard() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
-                      <CaretDownFilled style={{ fontSize: '10px' }} />
+                      <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }} />
+                      {filtersExpanded ?
+                        <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} /> :
+                        <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>
                 }
@@ -2254,7 +2254,7 @@ export default function Chessboard() {
                   padding: '4px 12px',
                   display: 'flex',
                   alignItems: 'center',
-                  borderColor: filtersExpanded ? '#1890ff' : undefined
+                    borderColor: filtersExpanded ? '#a69ead' : undefined
                 }}
               >
                 Фильтры

--- a/src/pages/references/Documentation.tsx
+++ b/src/pages/references/Documentation.tsx
@@ -1507,10 +1507,10 @@ export default function Documentation() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                    <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#1890ff' : undefined }} />
-                    {filtersExpanded ? 
-                      <CaretUpFilled style={{ fontSize: '10px', color: '#1890ff' }} /> : 
-                      <CaretDownFilled style={{ fontSize: '10px' }} />
+                      <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }} />
+                      {filtersExpanded ?
+                        <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} /> :
+                        <CaretDownFilled style={{ fontSize: '10px' }} />
                     }
                   </span>
                 }


### PR DESCRIPTION
## Summary
- update header and sidebar colors to `#f0edf2`
- switch interactive blue accents to `#a69ead`
- configure Ant Design theme tokens for new palette

## Testing
- `npm run lint` *(fails: Unexpected any and other existing issues)*
- `npm run build` *(fails: JSX elements cannot have multiple attributes with the same name)*

------
https://chatgpt.com/codex/tasks/task_e_68affdb3af30832ea260200b1d1fd6ff