### PR TITLE
feat: distribute material quantities per floor

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState, useEffect, type Key } from 'react'
-import { App, Badge, Button, Card, Checkbox, Drawer, Dropdown, Input, List, Modal, Popconfirm, Select, Space, Table, Typography, Upload } from 'antd'
+import { App, Badge, Button, Card, Checkbox, Drawer, Dropdown, Input, InputNumber, List, Modal, Popconfirm, Select, Space, Table, Typography, Upload } from 'antd'
 import type { ColumnType, ColumnsType } from 'antd/es/table'
 import { ArrowDownOutlined, ArrowUpOutlined, BgColorsOutlined, CopyOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, InboxOutlined, PlusOutlined, SaveOutlined, SettingOutlined, FilterOutlined, CaretUpFilled, CaretDownFilled, UploadOutlined } from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
@@ -52,6 +52,14 @@ const RowColorPicker = ({
   </Dropdown>
 )
 
+interface FloorQuantity {
+  quantityPd: string
+  quantitySpec: string
+  quantityRd: string
+}
+
+type FloorQuantities = Record<number, FloorQuantity>
+
 interface RowData {
   key: string
   material: string
@@ -71,6 +79,7 @@ interface RowData {
   tagId?: string
   tagName?: string
   projectCode?: string
+  floorQuantities?: FloorQuantities
 }
 
 interface ViewRow {
@@ -124,6 +133,7 @@ interface DbRow {
   unit_id: string | null
   color: string | null
   floors?: string
+  floorQuantities?: FloorQuantities
   units?: { name: string | null } | null
   chessboard_mapping?: {
     block_id: string | null
@@ -226,6 +236,7 @@ const emptyRow = (defaults: Partial<RowData>): RowData => ({
   rateId: '',
   floors: defaults.floors ?? '',
   color: '',
+  floorQuantities: undefined,
 })
 
 type HiddenColKey = 'block' | 'costCategory' | 'costType' | 'location'
@@ -520,37 +531,55 @@ export default function Chessboard() {
       
       // Загружаем этажи для всех записей
       const chessboardIds = (data as any[])?.map(item => item.id) || []
-      let floorsMap: Record<string, string> = {}
-      
+      let floorsMap: Record<string, { floors: string; quantities: FloorQuantities }> = {}
+
       if (chessboardIds.length > 0) {
         const { data: floorsData } = await supabase
           .from('chessboard_floor_mapping')
-          .select('chessboard_id, floor_number')
+          .select('chessboard_id, floor_number, "quantityPd", "quantitySpec", "quantityRd"')
           .in('chessboard_id', chessboardIds)
           .order('floor_number', { ascending: true })
-        
-        // Группируем этажи по chessboard_id и преобразуем в строки с диапазонами
+
+        // Группируем этажи по chessboard_id и сохраняем количества
         if (floorsData) {
-          const grouped: Record<string, number[]> = {}
+          const grouped: Record<string, { floors: number[]; quantities: FloorQuantities }> = {}
           floorsData.forEach((item: any) => {
             if (!grouped[item.chessboard_id]) {
-              grouped[item.chessboard_id] = []
+              grouped[item.chessboard_id] = { floors: [], quantities: {} }
             }
-            grouped[item.chessboard_id].push(item.floor_number)
+            grouped[item.chessboard_id].floors.push(item.floor_number)
+            grouped[item.chessboard_id].quantities[item.floor_number] = {
+              quantityPd:
+                item.quantityPd !== null && item.quantityPd !== undefined
+                  ? String(item.quantityPd)
+                  : '',
+              quantitySpec:
+                item.quantitySpec !== null && item.quantitySpec !== undefined
+                  ? String(item.quantitySpec)
+                  : '',
+              quantityRd:
+                item.quantityRd !== null && item.quantityRd !== undefined
+                  ? String(item.quantityRd)
+                  : '',
+            }
           })
-          
+
           // Преобразуем массивы этажей в строки с диапазонами
-          for (const [id, floors] of Object.entries(grouped)) {
-            floorsMap[id] = formatFloorsString(floors)
+          for (const [id, { floors, quantities }] of Object.entries(grouped)) {
+            floorsMap[id] = {
+              floors: formatFloorsString(floors),
+              quantities,
+            }
           }
         }
       }
-      
-      // Добавляем этажи к результатам
+
+      // Добавляем этажи и количества к результатам
       const result = (data as unknown as DbRow[]) ?? []
       return result.map(item => ({
         ...item,
-        floors: floorsMap[item.id] || ''
+        floors: floorsMap[item.id]?.floors || '',
+        floorQuantities: floorsMap[item.id]?.quantities,
       }))
     },
   })
@@ -560,12 +589,45 @@ export default function Chessboard() {
       (tableData ?? []).map((item) => {
         const documentation = item.chessboard_documentation_mapping?.documentations
         const tag = documentation?.tag
+        const sumPd = item.floorQuantities
+          ? Object.values(item.floorQuantities).reduce(
+              (s, q) => s + (parseFloat(q.quantityPd) || 0),
+              0,
+            )
+          : null
+        const sumSpec = item.floorQuantities
+          ? Object.values(item.floorQuantities).reduce(
+              (s, q) => s + (parseFloat(q.quantitySpec) || 0),
+              0,
+            )
+          : null
+        const sumRd = item.floorQuantities
+          ? Object.values(item.floorQuantities).reduce(
+              (s, q) => s + (parseFloat(q.quantityRd) || 0),
+              0,
+            )
+          : null
         return {
           key: item.id,
           material: item.material ?? '',
-          quantityPd: item.quantityPd !== null && item.quantityPd !== undefined ? String(item.quantityPd) : '',
-          quantitySpec: item.quantitySpec !== null && item.quantitySpec !== undefined ? String(item.quantitySpec) : '',
-          quantityRd: item.quantityRd !== null && item.quantityRd !== undefined ? String(item.quantityRd) : '',
+          quantityPd:
+            sumPd !== null
+              ? String(sumPd)
+              : item.quantityPd !== null && item.quantityPd !== undefined
+              ? String(item.quantityPd)
+              : '',
+          quantitySpec:
+            sumSpec !== null
+              ? String(sumSpec)
+              : item.quantitySpec !== null && item.quantitySpec !== undefined
+              ? String(item.quantitySpec)
+              : '',
+          quantityRd:
+            sumRd !== null
+              ? String(sumRd)
+              : item.quantityRd !== null && item.quantityRd !== undefined
+              ? String(item.quantityRd)
+              : '',
           unit: item.units?.name ?? '',
           blockId: item.chessboard_mapping?.block_id ?? '',
           block: item.chessboard_mapping?.blocks?.name ?? '',
@@ -712,6 +774,105 @@ export default function Chessboard() {
     [],
   )
 
+  const [floorModalOpen, setFloorModalOpen] = useState(false)
+  const [floorModalRowKey, setFloorModalRowKey] = useState<string | null>(null)
+  const [floorModalIsEdit, setFloorModalIsEdit] = useState(false)
+  const [floorModalData, setFloorModalData] = useState<
+    { floor: number; quantityPd: string; quantitySpec: string; quantityRd: string }[]
+  >([])
+
+  const openFloorModal = useCallback(
+    (key: string, isEdit: boolean) => {
+      const row = isEdit ? editingRows[key] : rows.find(r => r.key === key)
+      if (!row) return
+      const floors = parseFloorsString(row.floors)
+      const quantities = row.floorQuantities || {}
+      const data = floors.map(f => ({
+        floor: f,
+        quantityPd: quantities[f]?.quantityPd || '',
+        quantitySpec: quantities[f]?.quantitySpec || '',
+        quantityRd: quantities[f]?.quantityRd || '',
+      }))
+      setFloorModalRowKey(key)
+      setFloorModalIsEdit(isEdit)
+      setFloorModalData(data)
+      setFloorModalOpen(true)
+    },
+    [editingRows, rows],
+  )
+
+  const handleFloorModalChange = useCallback(
+    (index: number, field: keyof FloorQuantity | 'floor', value: string | number) => {
+      setFloorModalData(prev =>
+        prev.map((item, i) =>
+          i === index ? { ...item, [field]: field === 'floor' ? Number(value) : String(value) } : item,
+        ),
+      )
+    },
+    [],
+  )
+
+  const addFloorModalRow = useCallback(() => {
+    setFloorModalData(prev => [...prev, { floor: 0, quantityPd: '', quantitySpec: '', quantityRd: '' }])
+  }, [])
+
+  const removeFloorModalRow = useCallback((index: number) => {
+    setFloorModalData(prev => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const saveFloorModal = useCallback(() => {
+    if (!floorModalRowKey) return
+    const map: FloorQuantities = {}
+    const floorNums: number[] = []
+    floorModalData.forEach(d => {
+      const num = Number(d.floor)
+      if (!isNaN(num)) {
+        floorNums.push(num)
+        map[num] = {
+          quantityPd: d.quantityPd,
+          quantitySpec: d.quantitySpec,
+          quantityRd: d.quantityRd,
+        }
+      }
+    })
+    floorNums.sort((a, b) => a - b)
+    const floorsStr = formatFloorsString(floorNums)
+    const totalPd = floorModalData.reduce((s, d) => s + (parseFloat(d.quantityPd) || 0), 0)
+    const totalSpec = floorModalData.reduce((s, d) => s + (parseFloat(d.quantitySpec) || 0), 0)
+    const totalRd = floorModalData.reduce((s, d) => s + (parseFloat(d.quantityRd) || 0), 0)
+    if (floorModalIsEdit) {
+      setEditingRows(prev => ({
+        ...prev,
+        [floorModalRowKey]: {
+          ...prev[floorModalRowKey],
+          floors: floorsStr,
+          quantityPd: totalPd ? String(totalPd) : '',
+          quantitySpec: totalSpec ? String(totalSpec) : '',
+          quantityRd: totalRd ? String(totalRd) : '',
+          floorQuantities: map,
+        },
+      }))
+    } else {
+      setRows(prev =>
+        prev.map(r =>
+          r.key === floorModalRowKey
+            ? {
+                ...r,
+                floors: floorsStr,
+                quantityPd: totalPd ? String(totalPd) : '',
+                quantitySpec: totalSpec ? String(totalSpec) : '',
+                quantityRd: totalRd ? String(totalRd) : '',
+                floorQuantities: map,
+              }
+            : r,
+        ),
+      )
+    }
+    setFloorModalOpen(false)
+  }, [floorModalRowKey, floorModalData, floorModalIsEdit, setEditingRows, setRows])
+
+  const cancelFloorModal = useCallback(() => setFloorModalOpen(false), [])
+
   const startAdd = useCallback(() => {
     if (!appliedFilters) return
     const defaultLocationId = appliedFilters.typeId
@@ -782,6 +943,7 @@ export default function Chessboard() {
               ? `${dbRow.chessboard_documentation_mapping.documentations.tag.tag_number || ''} ${dbRow.chessboard_documentation_mapping.documentations.tag.name}`.trim()
               : '',
             projectCode: dbRow.chessboard_documentation_mapping?.documentations?.code ?? '',
+            floorQuantities: dbRow.floorQuantities,
           },
         }
       })
@@ -823,16 +985,32 @@ export default function Chessboard() {
         await supabase!.from('chessboard_floor_mapping')
           .delete()
           .eq('chessboard_id', r.key)
-        
+
         // Парсим строку этажей и добавляем новые
         const floors = parseFloorsString(r.floors)
         if (floors.length > 0) {
+          const totalFloors = floors.length
+          const floorQuantities = r.floorQuantities
           const floorMappings = floors.map(floor => ({
             chessboard_id: r.key,
-            floor_number: floor
+            floor_number: floor,
+            quantityPd: floorQuantities?.[floor]?.quantityPd
+              ? Number(floorQuantities[floor].quantityPd)
+              : r.quantityPd
+              ? Number(r.quantityPd) / totalFloors
+              : null,
+            quantitySpec: floorQuantities?.[floor]?.quantitySpec
+              ? Number(floorQuantities[floor].quantitySpec)
+              : r.quantitySpec
+              ? Number(r.quantitySpec) / totalFloors
+              : null,
+            quantityRd: floorQuantities?.[floor]?.quantityRd
+              ? Number(floorQuantities[floor].quantityRd)
+              : r.quantityRd
+              ? Number(r.quantityRd) / totalFloors
+              : null,
           }))
-          await supabase!.from('chessboard_floor_mapping')
-            .insert(floorMappings)
+          await supabase!.from('chessboard_floor_mapping').insert(floorMappings)
         }
       }
       
@@ -1064,9 +1242,26 @@ export default function Chessboard() {
     for (let idx = 0; idx < data.length; idx++) {
       const floors = parseFloorsString(rows[idx].floors)
       if (floors.length > 0) {
+        const totalFloors = floors.length
+        const floorQuantities = rows[idx].floorQuantities
         const floorMappings = floors.map(floor => ({
           chessboard_id: data[idx].id,
-          floor_number: floor
+          floor_number: floor,
+          quantityPd: floorQuantities?.[floor]?.quantityPd
+            ? Number(floorQuantities[floor].quantityPd)
+            : rows[idx].quantityPd
+            ? Number(rows[idx].quantityPd) / totalFloors
+            : null,
+          quantitySpec: floorQuantities?.[floor]?.quantitySpec
+            ? Number(floorQuantities[floor].quantitySpec)
+            : rows[idx].quantitySpec
+            ? Number(rows[idx].quantitySpec) / totalFloors
+            : null,
+          quantityRd: floorQuantities?.[floor]?.quantityRd
+            ? Number(floorQuantities[floor].quantityRd)
+            : rows[idx].quantityRd
+            ? Number(rows[idx].quantityRd) / totalFloors
+            : null,
         }))
         const { error: floorError } = await supabase.from('chessboard_floor_mapping').insert(floorMappings)
         if (floorError) {
@@ -1285,11 +1480,20 @@ export default function Chessboard() {
             )
           case 'quantityPd':
             return (
-              <Input
-                style={{ width: '10ch' }}
-                value={record.quantityPd}
-                onChange={(e) => handleRowChange(record.key, 'quantityPd', e.target.value)}
-              />
+              <Space>
+                {parseFloorsString(record.floors).length > 1 && (
+                  <Button
+                    type="text"
+                    icon={<PlusOutlined />}
+                    onClick={() => openFloorModal(record.key, false)}
+                  />
+                )}
+                <Input
+                  style={{ width: '10ch' }}
+                  value={record.quantityPd}
+                  onChange={(e) => handleRowChange(record.key, 'quantityPd', e.target.value)}
+                />
+              </Space>
             )
           case 'quantitySpec':
             return (
@@ -1670,11 +1874,20 @@ export default function Chessboard() {
             )
           case 'quantityPd':
             return (
-              <Input
-                style={{ width: '10ch' }}
-                value={edit.quantityPd}
-                onChange={(e) => handleEditChange(record.key, 'quantityPd', e.target.value)}
-              />
+              <Space>
+                {parseFloorsString(edit.floors).length > 1 && (
+                  <Button
+                    type="text"
+                    icon={<PlusOutlined />}
+                    onClick={() => openFloorModal(record.key, true)}
+                  />
+                )}
+                <Input
+                  style={{ width: '10ch' }}
+                  value={edit.quantityPd}
+                  onChange={(e) => handleEditChange(record.key, 'quantityPd', e.target.value)}
+                />
+              </Space>
             )
           case 'quantitySpec':
             return (
@@ -2536,6 +2749,49 @@ export default function Chessboard() {
         )}
         </div>
       )}
+      <Modal
+        title="Количество по этажам"
+        open={floorModalOpen}
+        onCancel={cancelFloorModal}
+        onOk={saveFloorModal}
+        okText="Сохранить"
+        cancelText="Отменить"
+      >
+        {floorModalData.map((item, index) => (
+          <Space key={index} style={{ marginBottom: 8 }}>
+            <InputNumber
+              value={item.floor}
+              onChange={(value) => handleFloorModalChange(index, 'floor', value ?? 0)}
+            />
+            <Input
+              style={{ width: '10ch' }}
+              value={item.quantityPd}
+              onChange={(e) => handleFloorModalChange(index, 'quantityPd', e.target.value)}
+              placeholder="Кол-во по ПД"
+            />
+            <Input
+              style={{ width: '10ch' }}
+              value={item.quantitySpec}
+              onChange={(e) => handleFloorModalChange(index, 'quantitySpec', e.target.value)}
+              placeholder="Кол-во по спеке РД"
+            />
+            <Input
+              style={{ width: '10ch' }}
+              value={item.quantityRd}
+              onChange={(e) => handleFloorModalChange(index, 'quantityRd', e.target.value)}
+              placeholder="Кол-во по пересчету РД"
+            />
+            <Button
+              type="text"
+              icon={<DeleteOutlined />}
+              onClick={() => removeFloorModalRow(index)}
+            />
+          </Space>
+        ))}
+        <Button type="dashed" icon={<PlusOutlined />} onClick={addFloorModalRow}>
+          Добавить этаж
+        </Button>
+      </Modal>
       <Modal
         title="Импорт из Excel"
         open={importOpen}

--- a/supabase/migrations/add_quantities_to_chessboard_floor_mapping.sql
+++ b/supabase/migrations/add_quantities_to_chessboard_floor_mapping.sql
@@ -1,0 +1,4 @@
+alter table if exists public.chessboard_floor_mapping
+  add column if not exists "quantityPd" numeric,
+  add column if not exists "quantitySpec" numeric,
+  add column if not exists "quantityRd" numeric;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -2906,6 +2906,9 @@ CREATE TABLE public.chessboard_floor_mapping (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     chessboard_id uuid NOT NULL,
     floor_number integer NOT NULL,
+    "quantityPd" numeric,
+    "quantitySpec" numeric,
+    "quantityRd" numeric,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- store material quantities per floor in chessboard_floor_mapping
- allow specifying per-floor quantities via modal on Chessboard page
- show total quantities and distribute values across floors when needed

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build` *(fails: JSX elements cannot have multiple attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68b042fd1c9c832eb830b8bb17be3101