### PR TITLE
feat: distribute material quantities per floor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Admin from './pages/Admin'
 import DocumentationTags from './pages/admin/DocumentationTags'
 import Statuses from './pages/admin/Statuses'
 import Disk from './pages/admin/Disk'
+import TransferQuantity from './pages/admin/TransferQuantity'
 import PortalHeader from './components/PortalHeader'
 import TestTableStructure from './pages/TestTableStructure'
 import logoLight from './logo_light.svg'
@@ -266,6 +267,15 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         </Link>
       </div>
       <div
+        style={menuItemStyle}
+        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
+        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+      >
+        <Link to="/admin/transfer-quantity" style={linkStyle}>
+          Перенос количества
+        </Link>
+      </div>
+      <div
         style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
         onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
@@ -334,6 +344,10 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         {
           key: 'disk',
           label: <Link to="/admin/disk">Диск</Link>
+        },
+        {
+          key: 'transfer-quantity',
+          label: <Link to="/admin/transfer-quantity">Перенос количества</Link>
         },
         {
           key: 'theme-toggle',
@@ -488,6 +502,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               location.pathname.startsWith('/admin/documentation-tags') ? 'documentation-tags' :
               location.pathname.startsWith('/admin/statuses') ? 'statuses' :
               location.pathname.startsWith('/admin/disk') ? 'disk' :
+              location.pathname.startsWith('/admin/transfer-quantity') ? 'transfer-quantity' :
               location.pathname
             ]}
             openKeys={openKeys}
@@ -522,6 +537,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
                 <Route path="documentation-tags" element={<DocumentationTags />} />
                 <Route path="statuses" element={<Statuses />} />
                 <Route path="disk" element={<Disk />} />
+                <Route path="transfer-quantity" element={<TransferQuantity />} />
               </Route>
               <Route path="/test-table" element={<TestTableStructure />} />
             </Routes>

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -29,6 +29,7 @@ const pageTitles: Record<string, string> = {
   '/admin/documentation-tags': 'Тэги документации',
   '/admin/statuses': 'Статусы',
   '/admin/disk': 'Диск',
+  '/admin/transfer-quantity': 'Перенос количества',
 };
 
 const getPageTitle = (path: string): string => {

--- a/src/pages/admin/TransferQuantity.tsx
+++ b/src/pages/admin/TransferQuantity.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Button, message } from 'antd'
+import { supabase } from '@/lib/supabase'
+
+interface ChessboardRow {
+  id: string
+  floors: string | null
+  quantityPd: string | null
+  quantitySpec: string | null
+  quantityRd: string | null
+}
+
+export default function TransferQuantity() {
+  const [loading, setLoading] = useState(false)
+
+  const handleTransfer = async () => {
+    if (!supabase) return
+    setLoading(true)
+    try {
+      const { data, error } = await supabase
+        .from('chessboard')
+        .select('id, floors, quantityPd, quantitySpec, quantityRd')
+      if (error) throw error
+
+      const rows = (data ?? []) as ChessboardRow[]
+      for (const row of rows) {
+        if (!row.floors) continue
+        const floors = parseFloorsString(row.floors)
+        if (floors.length === 0) continue
+        const count = floors.length
+        const qPd = (Number(row.quantityPd) || 0) / count
+        const qSpec = (Number(row.quantitySpec) || 0) / count
+        const qRd = (Number(row.quantityRd) || 0) / count
+
+        await supabase
+          .from('chessboard_floor_mapping')
+          .delete()
+          .eq('chessboard_id', row.id)
+
+        for (const floor of floors) {
+          const { error: insertError } = await supabase
+            .from('chessboard_floor_mapping')
+            .upsert(
+              {
+                chessboard_id: row.id,
+                floor_number: floor,
+                quantityPd: qPd || null,
+                quantitySpec: qSpec || null,
+                quantityRd: qRd || null,
+              },
+              { onConflict: 'chessboard_id,floor_number' },
+            )
+          if (insertError) throw insertError
+        }
+      }
+      message.success('Перенос завершён')
+    } catch (e) {
+      const err = e as Error
+      message.error(`Ошибка переноса: ${err.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <h2>Перенос количества</h2>
+      <Button type="primary" onClick={handleTransfer} loading={loading}>
+        Перенести
+      </Button>
+    </div>
+  )
+}
+
+function parseFloorsString(floorsStr: string): number[] {
+  if (!floorsStr || !floorsStr.trim()) return []
+  const floors = new Set<number>()
+  const parts = floorsStr.split(',').map(s => s.trim())
+  for (const part of parts) {
+    if (part.includes('-')) {
+      const [start, end] = part.split('-').map(s => parseInt(s.trim(), 10))
+      if (!isNaN(start) && !isNaN(end)) {
+        for (let i = Math.min(start, end); i <= Math.max(start, end); i++) {
+          floors.add(i)
+        }
+      }
+    } else {
+      const num = parseInt(part, 10)
+      if (!isNaN(num)) floors.add(num)
+    }
+  }
+  return Array.from(floors).sort((a, b) => a - b)
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -36,6 +36,7 @@ export const PORTAL_PAGES = [
   { key: 'references/locations', label: 'Справочники → Локализации' },
   { key: 'admin/documentation-tags', label: 'Администрирование → Тэги документации' },
   { key: 'admin/statuses', label: 'Администрирование → Статусы' },
+  { key: 'admin/transfer-quantity', label: 'Администрирование → Перенос количества' },
 ] as const
 
 export type PortalPageKey = typeof PORTAL_PAGES[number]['key']

--- a/supabase/migrations/add_quantities_to_chessboard_floor_mapping.sql
+++ b/supabase/migrations/add_quantities_to_chessboard_floor_mapping.sql
@@ -1,0 +1,4 @@
+alter table if exists public.chessboard_floor_mapping
+  add column if not exists "quantityPd" numeric,
+  add column if not exists "quantitySpec" numeric,
+  add column if not exists "quantityRd" numeric;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -2906,6 +2906,9 @@ CREATE TABLE public.chessboard_floor_mapping (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     chessboard_id uuid NOT NULL,
     floor_number integer NOT NULL,
+    "quantityPd" numeric,
+    "quantitySpec" numeric,
+    "quantityRd" numeric,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- store material quantities per floor in chessboard_floor_mapping
- allow specifying per-floor quantities via modal on Chessboard page
- show total quantities and distribute values across floors when needed
- add admin tool to transfer quantities from chessboard to floor mapping
- show project and material info in floor quantity modal and add column headers

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run build` *(fails: Property 'children' does not exist, duplicate attributes in Chessboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b042fd1c9c832eb830b8bb17be3101