### PR TITLE
feat: add nomenclature column to chessboard

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect, type Key } from 'react'
+import { useCallback, useMemo, useState, useEffect, type Key, isValidElement, type ReactNode } from 'react'
 import { App, Badge, Button, Card, Checkbox, Drawer, Dropdown, Input, InputNumber, List, Modal, Popconfirm, Select, Space, Table, Typography, Upload } from 'antd'
 import type { ColumnType, ColumnsType } from 'antd/es/table'
 import { ArrowDownOutlined, ArrowUpOutlined, BgColorsOutlined, CopyOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, InboxOutlined, PlusOutlined, SaveOutlined, SettingOutlined, FilterOutlined, CaretUpFilled, CaretDownFilled, UploadOutlined } from '@ant-design/icons'
@@ -66,6 +66,7 @@ interface RowData {
   quantityPd: string
   quantitySpec: string
   quantityRd: string
+  nomenclatureId: string
   unitId: string
   blockId: string
   block: string
@@ -102,6 +103,8 @@ interface ViewRow {
   quantityPd: string
   quantitySpec: string
   quantityRd: string
+  nomenclature: string
+  nomenclatureId: string
   unit: string
   blockId: string
   block: string
@@ -123,6 +126,7 @@ interface TableRow extends RowData {
 interface ProjectOption { id: string; name: string }
 interface BlockOption { id: string; name: string }
 interface UnitOption { id: string; name: string }
+interface MaterialOption { id: string; name: string }
 interface CostCategoryOption { id: number; number: number | null; name: string }
 interface CostTypeOption {
   id: number
@@ -138,9 +142,18 @@ interface RateOption {
   rates_detail_cost_categories_mapping: { detail_cost_category_id: number }[] | null
 }
 
+interface DocumentationOption {
+  id: string
+  project_code: string
+  tag_id: number | null
+  tag_name?: string
+  tag_number?: number | null
+}
+
 interface DbRow {
   id: string
   material: string | null
+  material_id: string | null
   quantityPd: number | null
   quantitySpec: number | null
   quantityRd: number | null
@@ -148,6 +161,7 @@ interface DbRow {
   color: string | null
   floors?: string
   floorQuantities?: FloorQuantities
+  materials?: { name: string | null } | null
   units?: { name: string | null } | null
   chessboard_mapping?: {
     block_id: string | null
@@ -177,6 +191,14 @@ interface DbRow {
       } | null
     } | null
   } | null
+}
+
+interface FloorRecord {
+  chessboard_id: string
+  floor_number: number
+  quantityPd: number | null
+  quantitySpec: number | null
+  quantityRd: number | null
 }
 
 // Функция для форматирования массива этажей в строку с диапазонами
@@ -241,6 +263,7 @@ const emptyRow = (defaults: Partial<RowData>): RowData => ({
   quantityPd: '',
   quantitySpec: '',
   quantityRd: '',
+  nomenclatureId: '',
   unitId: '',
   blockId: defaults.blockId ?? '',
   block: defaults.block ?? '',
@@ -390,6 +413,16 @@ export default function Chessboard() {
     },
   })
 
+  const { data: materials } = useQuery<MaterialOption[]>({
+    queryKey: ['materials'],
+    queryFn: async () => {
+      if (!supabase) return []
+      const { data, error } = await supabase.from('materials').select('id, name').order('name')
+      if (error) throw error
+      return data as MaterialOption[]
+    },
+  })
+
   const { data: costCategories } = useQuery<CostCategoryOption[]>({
     queryKey: ['costCategories'],
     queryFn: async () => {
@@ -464,21 +497,21 @@ export default function Chessboard() {
     queryFn: documentationTagsApi.getAll,
   })
 
-  // Загрузка документации для выбранного проекта  
-  const { data: documentations } = useQuery<any[]>({
+  // Загрузка документации для выбранного проекта
+  const { data: documentations } = useQuery<DocumentationOption[]>({
     queryKey: ['documentations', appliedFilters?.projectId],
     queryFn: async () => {
-      console.log('📚 DOCUMENTATION QUERY - Executing:', { 
+      console.log('📚 DOCUMENTATION QUERY - Executing:', {
         projectId: appliedFilters?.projectId,
-        enabled: !!appliedFilters?.projectId 
+        enabled: !!appliedFilters?.projectId
       })
       if (!appliedFilters?.projectId) {
         console.log('⚠️ DOCUMENTATION QUERY - No project ID, returning empty array')
         return []
       }
-      const fetchFilters: any = { project_id: appliedFilters.projectId }
+      const fetchFilters: Record<string, unknown> = { project_id: appliedFilters.projectId }
       const result = await documentationApi.getDocumentation(fetchFilters)
-      
+
       console.log('✅ DOCUMENTATION QUERY - Loaded:', {
         projectId: appliedFilters.projectId,
         totalCount: result.length,
@@ -491,7 +524,7 @@ export default function Chessboard() {
           tag_number: doc.tag_number
         }))
       })
-      return result
+      return result as DocumentationOption[]
     },
     enabled: !!appliedFilters?.projectId,
   })
@@ -519,7 +552,7 @@ export default function Chessboard() {
       const query = supabase
         .from('chessboard')
         .select(
-          `id, material, quantityPd, quantitySpec, quantityRd, unit_id, color, units(name),
+          `id, material, material_id, quantityPd, quantitySpec, quantityRd, unit_id, color, materials(name), units(name),
           ${relation}(block_id, blocks(name), cost_category_id, cost_type_id, location_id, cost_categories(name), detail_cost_categories(name), location(name)),
           chessboard_rates_mapping(rate_id, rates(work_name)),
           chessboard_documentation_mapping(documentation_id, documentations(id, code, tag_id, stage, tag:documentation_tags(id, name, tag_number)))`,
@@ -544,8 +577,8 @@ export default function Chessboard() {
       }
       
       // Загружаем этажи для всех записей
-      const chessboardIds = (data as any[])?.map(item => item.id) || []
-      let floorsMap: Record<string, { floors: string; quantities: FloorQuantities }> = {}
+      const chessboardIds = (data ?? []).map(item => item.id)
+      const floorsMap: Record<string, { floors: string; quantities: FloorQuantities }> = {}
 
       if (chessboardIds.length > 0) {
         const { data: floorsData } = await supabase
@@ -556,8 +589,9 @@ export default function Chessboard() {
 
         // Группируем этажи по chessboard_id и сохраняем количества
         if (floorsData) {
+          const typedFloors = floorsData as FloorRecord[]
           const grouped: Record<string, { floors: number[]; quantities: FloorQuantities }> = {}
-          floorsData.forEach((item: any) => {
+          typedFloors.forEach((item) => {
             if (!grouped[item.chessboard_id]) {
               grouped[item.chessboard_id] = { floors: [], quantities: {} }
             }
@@ -624,6 +658,8 @@ export default function Chessboard() {
         return {
           key: item.id,
           material: item.material ?? '',
+          nomenclature: item.materials?.name ?? '',
+          nomenclatureId: item.material_id ?? '',
           quantityPd:
             sumPd !== null
               ? String(sumPd)
@@ -665,6 +701,7 @@ export default function Chessboard() {
       ...viewRows.map((v) => ({
         key: v.key,
         material: v.material,
+        nomenclatureId: v.nomenclature,
         quantityPd: v.quantityPd,
         quantitySpec: v.quantitySpec,
         quantityRd: v.quantityRd,
@@ -760,8 +797,9 @@ export default function Chessboard() {
       setSelectedRows(new Set())
       setDeleteMode(false)
       await refetch()
-    } catch (error: any) {
-      message.error(`Не удалось удалить строки: ${error.message}`)
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error)
+      message.error(`Не удалось удалить строки: ${errMsg}`)
     }
   }, [selectedRows, message, refetch])
   
@@ -800,7 +838,7 @@ export default function Chessboard() {
         ? editingRows[key] ?? rows.find(r => r.key === key) ?? tableData?.find(r => r.id === key)
         : rows.find(r => r.key === key) ?? tableData?.find(r => r.id === key)
       if (!row) return
-      const floors = parseFloorsString(row.floors)
+      const floors = parseFloorsString(row.floors || '')
       const quantities = row.floorQuantities || {}
       const data = floors.map(f => ({
         floor: f,
@@ -819,11 +857,11 @@ export default function Chessboard() {
       const projectCode =
         'projectCode' in row
           ? row.projectCode
-          : row.chessboard_documentation_mapping?.documentations?.code ?? ''
+          : (row as DbRow).chessboard_documentation_mapping?.documentations?.code ?? ''
       setFloorModalInfo({
         projectCode,
         workName,
-        material: row.material,
+        material: row.material ?? '',
         unit: unitName,
       })
       setFloorModalRowKey(key)
@@ -1023,13 +1061,14 @@ export default function Chessboard() {
               dbRow.quantitySpec !== null && dbRow.quantitySpec !== undefined
                 ? String(dbRow.quantitySpec)
                 : '',
-            quantityRd:
-              dbRow.quantityRd !== null && dbRow.quantityRd !== undefined
-                ? String(dbRow.quantityRd)
-                : '',
-            unitId: dbRow.unit_id ?? '',
-            blockId: dbRow.chessboard_mapping?.block_id ?? '',
-            block: dbRow.chessboard_mapping?.blocks?.name ?? '',
+          quantityRd:
+            dbRow.quantityRd !== null && dbRow.quantityRd !== undefined
+              ? String(dbRow.quantityRd)
+              : '',
+          nomenclatureId: dbRow.material_id ?? '',
+          unitId: dbRow.unit_id ?? '',
+          blockId: dbRow.chessboard_mapping?.block_id ?? '',
+          block: dbRow.chessboard_mapping?.blocks?.name ?? '',
             costCategoryId: dbRow.chessboard_mapping?.cost_category_id
               ? String(dbRow.chessboard_mapping.cost_category_id)
               : '',
@@ -1069,6 +1108,7 @@ export default function Chessboard() {
         .from('chessboard')
         .update({
           material: r.material,
+          material_id: r.nomenclatureId || null,
           quantityPd: r.quantityPd ? Number(r.quantityPd) : null,
           quantitySpec: r.quantitySpec ? Number(r.quantitySpec) : null,
           quantityRd: r.quantityRd ? Number(r.quantityRd) : null,
@@ -1185,8 +1225,9 @@ export default function Chessboard() {
       message.success('Изменения сохранены')
       setEditingRows({})
       await refetch()
-    } catch (error: any) {
-      message.error(`Не удалось сохранить изменения: ${error.message}`)
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error)
+      message.error(`Не удалось сохранить изменения: ${errMsg}`)
     }
   }, [editingRows, message, refetch, appliedFilters])
 
@@ -1318,6 +1359,7 @@ export default function Chessboard() {
     const payload = rows.map((r) => ({
       project_id: appliedFilters.projectId,
       material: r.material,
+      material_id: r.nomenclatureId || null,
       quantityPd: r.quantityPd ? Number(r.quantityPd) : null,
       quantitySpec: r.quantitySpec ? Number(r.quantitySpec) : null,
       quantityRd: r.quantityRd ? Number(r.quantityRd) : null,
@@ -1396,12 +1438,12 @@ export default function Chessboard() {
     for (let idx = 0; idx < data.length; idx++) {
       let docId = rows[idx].documentationId
 
-      if (!docId && rows[idx].projectCode && rows[idx].tagId) {
-        const doc = await documentationApi.upsertDocumentation(
-          rows[idx].projectCode,
-          Number(rows[idx].tagId),
-          appliedFilters.projectId,
-        )
+        if (!docId && rows[idx].projectCode && rows[idx].tagId) {
+          const doc = await documentationApi.upsertDocumentation(
+            rows[idx].projectCode!,
+            Number(rows[idx].tagId),
+            appliedFilters.projectId,
+          )
         docId = doc.id
       }
 
@@ -1434,6 +1476,7 @@ export default function Chessboard() {
       quantityPd: 'quantityPd',
       quantitySpec: 'quantitySpec',
       quantityRd: 'quantityRd',
+      nomenclatureId: 'nomenclature',
       unitId: 'unit',
       block: 'block',
       costCategoryId: 'costCategory',
@@ -1459,6 +1502,7 @@ export default function Chessboard() {
         width: 180,
         align: 'center',
       },
+      { title: 'Номенклатура', dataIndex: 'nomenclatureId', width: 250 },
       { title: 'Ед.изм.', dataIndex: 'unitId', width: 160 },
       { title: 'Корпус', dataIndex: 'block', width: 120 },
       { title: 'Этажи', dataIndex: 'floors', width: 150 },
@@ -1533,15 +1577,6 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
                   const label = option?.label
                   if (typeof label === 'string') {
                     return label.toLowerCase().includes(input.toLowerCase())
@@ -1557,7 +1592,9 @@ export default function Chessboard() {
                 value={record.documentationId}
                 onDropdownVisibleChange={(open) => {
                   if (open) {
-                    const filteredDocs = documentations?.filter((doc: any) => !record.tagId || String(doc.tag_id) === record.tagId) ?? []
+                    const filteredDocs = documentations?.filter(
+                      (doc) => !record.tagId || String(doc.tag_id) === record.tagId
+                    ) ?? []
                     console.log('🔽 ADD MODE - Project Code dropdown opened:', {
                       recordKey: record.key,
                       tagId: record.tagId,
@@ -1570,12 +1607,12 @@ export default function Chessboard() {
                 onChange={(value) => {
                   console.log('✏️ ADD MODE - Project Code selected:', { value, recordKey: record.key })
                   handleRowChange(record.key, 'documentationId', value)
-                  const doc = documentations?.find((d: any) => d.id === value)
+                  const doc = documentations?.find((d) => d.id === value)
                   handleRowChange(record.key, 'projectCode', doc?.project_code ?? '')
                 }}
                 options={
                   documentations
-                    ?.filter((doc: any) => {
+                    ?.filter((doc) => {
                       const matches = !record.tagId || String(doc.tag_id) === record.tagId
                       console.log('🔍 ADD MODE - Filtering documentation:', {
                         docId: doc.id,
@@ -1587,7 +1624,7 @@ export default function Chessboard() {
                       })
                       return matches
                     })
-                    .map((doc: any) => ({
+                    .map((doc) => ({
                       value: doc.id,
                       label: doc.project_code
                     })) ?? []
@@ -1596,20 +1633,8 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
-                  const label = option?.label
-                  if (typeof label === 'string') {
-                    return label.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
                 }}
               />
             )
@@ -1652,6 +1677,19 @@ export default function Chessboard() {
                 style={{ width: '10ch' }}
                 value={record.quantityRd}
                 onChange={(e) => handleRowChange(record.key, 'quantityRd', e.target.value)}
+              />
+            )
+          case 'nomenclatureId':
+            return (
+              <Select
+                style={{ width: 250 }}
+                value={record.nomenclatureId}
+                onChange={(value) => handleRowChange(record.key, 'nomenclatureId', value)}
+                options={materials?.map(m => ({ value: m.id, label: m.name })) ?? []}
+                showSearch
+                filterOption={(input, option) =>
+                  (option?.label ?? '').toString().toLowerCase().includes(input.toLowerCase())
+                }
               />
             )
           case 'unitId':
@@ -1838,11 +1876,14 @@ export default function Chessboard() {
     handleDelete,
     addRow,
     copyRow,
+    deleteRow,
     rows,
     hiddenCols,
     columnVisibility,
     columnOrder,
     getRateOptions,
+    openFloorModal,
+    materials,
   ])
 
   const viewColumns: ColumnsType<ViewRow> = useMemo(() => {
@@ -1877,6 +1918,7 @@ export default function Chessboard() {
         width: 180,
         align: 'center',
       },
+      { title: 'Номенклатура', dataIndex: 'nomenclature', width: 250 },
       { title: 'Ед.изм.', dataIndex: 'unit', width: 160 },
       { title: 'Корпус', dataIndex: 'block', width: 120 },
       { title: 'Этажи', dataIndex: 'floors', width: 150 },
@@ -1954,15 +1996,6 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
                   const label = option?.label
                   if (typeof label === 'string') {
                     return label.toLowerCase().includes(input.toLowerCase())
@@ -1978,7 +2011,9 @@ export default function Chessboard() {
                 value={edit.documentationId}
                 onDropdownVisibleChange={(open) => {
                   if (open) {
-                    const filteredDocs = documentations?.filter((doc: any) => !edit.tagId || String(doc.tag_id) === edit.tagId) ?? []
+                    const filteredDocs = documentations?.filter(
+                      (doc) => !edit.tagId || String(doc.tag_id) === edit.tagId
+                    ) ?? []
                     console.log('🔽 EDIT MODE - Project Code dropdown opened:', {
                       recordKey: record.key,
                       tagId: edit.tagId,
@@ -1991,12 +2026,12 @@ export default function Chessboard() {
                 onChange={(value) => {
                   console.log('✏️ EDIT MODE - Project Code selected:', { value, recordKey: record.key })
                   handleEditChange(record.key, 'documentationId', value)
-                  const doc = documentations?.find((d: any) => d.id === value)
+                  const doc = documentations?.find((d) => d.id === value)
                   handleEditChange(record.key, 'projectCode', doc?.project_code ?? '')
                 }}
                 options={
                   documentations
-                    ?.filter((doc: any) => {
+                    ?.filter((doc) => {
                       const matches = !edit.tagId || String(doc.tag_id) === edit.tagId
                       console.log('🔍 EDIT MODE - Filtering documentation:', {
                         docId: doc.id,
@@ -2008,7 +2043,7 @@ export default function Chessboard() {
                       })
                       return matches
                     })
-                    .map((doc: any) => ({
+                    .map((doc) => ({
                       value: doc.id,
                       label: doc.project_code
                     })) ?? []
@@ -2017,20 +2052,8 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
-                  const label = option?.label
-                  if (typeof label === 'string') {
-                    return label.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
                 }}
               />
             )
@@ -2073,6 +2096,19 @@ export default function Chessboard() {
                 style={{ width: '10ch' }}
                 value={edit.quantityRd}
                 onChange={(e) => handleEditChange(record.key, 'quantityRd', e.target.value)}
+              />
+            )
+          case 'nomenclature':
+            return (
+              <Select
+                style={{ width: 250 }}
+                value={edit.nomenclatureId}
+                onChange={(value) => handleEditChange(record.key, 'nomenclatureId', value)}
+                options={materials?.map(m => ({ value: m.id, label: m.name })) ?? []}
+                showSearch
+                filterOption={(input, option) =>
+                  (option?.label ?? '').toString().toLowerCase().includes(input.toLowerCase())
+                }
               />
             )
           case 'unit':
@@ -2199,7 +2235,7 @@ export default function Chessboard() {
               />
             )
           default:
-            return (record as any)[col.dataIndex]
+            return (record as unknown as Record<string, ReactNode>)[col.dataIndex]
         }
       }
 
@@ -2207,8 +2243,8 @@ export default function Chessboard() {
         ...col,
         filterSearch: true,
         sorter: (a: ViewRow, b: ViewRow) => {
-          const aVal = (a as any)[col.dataIndex]
-          const bVal = (b as any)[col.dataIndex]
+          const aVal = (a as unknown as Record<string, unknown>)[col.dataIndex]
+          const bVal = (b as unknown as Record<string, unknown>)[col.dataIndex]
           const aNum = Number(aVal)
           const bNum = Number(bVal)
           if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
@@ -2287,6 +2323,7 @@ export default function Chessboard() {
     columnOrder,
     getRateOptions,
     openFloorModal,
+    materials,
   ])
 
   const { Text } = Typography
@@ -2305,6 +2342,7 @@ export default function Chessboard() {
     { key: 'quantityPd', title: 'Кол-во по ПД' },
     { key: 'quantitySpec', title: 'Кол-во по спеке РД' },
     { key: 'quantityRd', title: 'Кол-во по пересчету РД' },
+    { key: 'nomenclature', title: 'Номенклатура' },
     { key: 'unit', title: 'Ед.изм.' },
   ], [])
 
@@ -2450,7 +2488,7 @@ export default function Chessboard() {
 
   // Применение порядка и видимости к столбцам таблицы
   const orderedViewColumns = useMemo(() => {
-    const columnsMap: Record<string, any> = {}
+    const columnsMap: Record<string, ColumnsType<ViewRow>[number]> = {}
     
     viewColumns.forEach(col => {
       if (col && 'dataIndex' in col) {
@@ -2498,7 +2536,7 @@ export default function Chessboard() {
 
   // Применение порядка и видимости к addColumns
   const orderedAddColumns = useMemo(() => {
-    const columnsMap: Record<string, any> = {}
+    const columnsMap: Record<string, ColumnsType<RowData>[number]> = {}
     
     addColumns.forEach(col => {
       if (col && 'dataIndex' in col) {
@@ -2569,44 +2607,25 @@ export default function Chessboard() {
               style={{ width: 280 }}
               size="large"
               allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
               showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const label = option?.label
+                  if (isValidElement(label)) {
+                    const text = (label.props as { children?: string }).children
+                    if (typeof text === 'string') {
+                      return text.toLowerCase().includes(input.toLowerCase())
+                    }
+                    return false
+                  }
+                  const text = String(label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
                 }}
               value={filters.projectId}
               onChange={(value) => setFilters({ projectId: value })}
-              options={projects?.map((p) => ({ 
-                value: p.id, 
-                label: <span style={{ fontWeight: 'bold' }}>{p.name}</span> 
+              options={projects?.map((p) => ({
+                value: p.id,
+                label: <span style={{ fontWeight: 'bold' }}>{p.name}</span>
               })) ?? []}
-              showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              filterOption={(input, option) => {
-                const label = option?.label
-                if (!label) return false
-                // Handle React elements (like bold text)
-                if (typeof label === 'object' && 'props' in label) {
-                  const text = (label as any).props?.children || ''
-                  if (typeof text === 'string') {
-                    return text.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
-                }
-                // Handle string labels
-                if (typeof label === 'string') {
-                  return (label as string).toLowerCase().includes(input.toLowerCase())
-                }
-                return false
-              }}
             />
             <Button 
               type="primary" 
@@ -2752,12 +2771,7 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
                 }}
               />
@@ -2788,7 +2802,7 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
                 }}
               />
@@ -2806,7 +2820,7 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
                 }}
               />
@@ -2824,15 +2838,6 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
                   const label = option?.label
                   if (typeof label === 'string') {
                     return label.toLowerCase().includes(input.toLowerCase())
@@ -2847,8 +2852,8 @@ export default function Chessboard() {
                 onChange={(value) => setFilters((f) => ({ ...f, documentationId: value }))}
                 options={
                   documentations
-                    ?.filter((doc: any) => !filters.tagId || String(doc.tag_id) === filters.tagId)
-                    .map((doc: any) => ({
+                    ?.filter((doc) => !filters.tagId || String(doc.tag_id) === filters.tagId)
+                    .map((doc) => ({
                       value: doc.id,
                       label: doc.project_code
                     })) ?? []
@@ -2857,20 +2862,8 @@ export default function Chessboard() {
                 allowClear
                 showSearch
                 filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
+                  const text = String(option?.label ?? '')
                   return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.children || option?.label)?.toString() || ""
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-                filterOption={(input, option) => {
-                  const label = option?.label
-                  if (typeof label === 'string') {
-                    return label.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
                 }}
               />
               </Space>

--- a/supabase.sql
+++ b/supabase.sql
@@ -44,6 +44,7 @@ create table if not exists chessboard (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references projects on delete cascade,
   material text,
+  material_id uuid references materials(id) on delete set null,
   "quantityPd" numeric,
   "quantitySpec" numeric,
   "quantityRd" numeric,


### PR DESCRIPTION
## Summary
- add selectable Nomenclature column tied to materials directory
- tidy Chessboard typings and dropdown filters
- persist material relations in schema

## Testing
- `npm run lint` *(fails: Unexpected any in other modules)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b06e6f536c832e9b34501e43a3c289