### PR TITLE
feat: add nomenclature column to chessboard

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -44,6 +44,7 @@ create table if not exists chessboard (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references projects on delete cascade,
   material text,
+  material_id uuid references materials(id) on delete set null,
   "quantityPd" numeric,
   "quantitySpec" numeric,
   "quantityRd" numeric,


### PR DESCRIPTION
## Summary
- add selectable Nomenclature column tied to materials directory
- tidy Chessboard typings and dropdown filters
- persist material relations in schema
- remove debug logging from Chessboard table

## Testing
- `npm run lint` *(fails: Unexpected any in other modules)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b06e6f536c832e9b34501e43a3c289