### PR TITLE
feat: add nomenclature selection to chessboard

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -47,6 +47,7 @@ create table if not exists chessboard (
   "quantityPd" numeric,
   "quantitySpec" numeric,
   "quantityRd" numeric,
+  nomenclature_id uuid references nomenclature on delete set null,
   unit_id uuid references units on delete set null,
   cost_category_code text,
   color text,

--- a/supabase/migrations/add_nomenclature_to_chessboard.sql
+++ b/supabase/migrations/add_nomenclature_to_chessboard.sql
@@ -1,0 +1,2 @@
+alter table if exists public.chessboard
+  add column if not exists nomenclature_id uuid references public.nomenclature(id) on delete set null;


### PR DESCRIPTION
## Summary
- add `nomenclature_id` to chessboard schema and migration
- allow choosing nomenclature in Chessboard table via searchable dropdown

## Testing
- `npm run lint` (fails: Unexpected any, unused vars)
- `npm run build` (fails: JSX elements with duplicate attributes)

------
https://chatgpt.com/codex/tasks/task_e_68b14d703e28832e8b8c171132e237b4