### PR TITLE
feat: map chessboard to nomenclature via mapping table

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -54,6 +54,14 @@ create table if not exists chessboard (
   updated_at timestamptz default now()
 );
 
+create table if not exists chessboard_nomenclature_mapping (
+  chessboard_id uuid references chessboard on delete cascade,
+  nomenclature_id uuid references nomenclature on delete cascade,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  primary key (chessboard_id, nomenclature_id)
+);
+
 -- reference data (renamed from reserved keyword "references")
 create table if not exists reference_data (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/migrations/create_chessboard_nomenclature_mapping.sql
+++ b/supabase/migrations/create_chessboard_nomenclature_mapping.sql
@@ -1,0 +1,16 @@
+create table if not exists public.chessboard_nomenclature_mapping (
+  chessboard_id uuid not null references public.chessboard(id) on delete cascade,
+  nomenclature_id uuid not null references public.nomenclature(id) on delete cascade,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  primary key (chessboard_id, nomenclature_id)
+);
+
+create index if not exists idx_chessboard_nomenclature_mapping_chessboard_id
+  on public.chessboard_nomenclature_mapping (chessboard_id);
+create index if not exists idx_chessboard_nomenclature_mapping_nomenclature_id
+  on public.chessboard_nomenclature_mapping (nomenclature_id);
+
+grant all on table public.chessboard_nomenclature_mapping to anon;
+grant all on table public.chessboard_nomenclature_mapping to authenticated;
+grant all on table public.chessboard_nomenclature_mapping to service_role;

--- a/supabase/migrations/drop_nomenclature_from_chessboard.sql
+++ b/supabase/migrations/drop_nomenclature_from_chessboard.sql
@@ -1,0 +1,2 @@
+alter table if exists public.chessboard
+  drop column if exists nomenclature_id;


### PR DESCRIPTION
## Summary
- decouple nomenclature from chessboard by removing foreign key and adding mapping table
- update chessboard logic to read and write nomenclature through mapping

## Testing
- `npm run lint`
- `npm run build` *(fails: JSX elements cannot have multiple attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68b14d703e28832e8b8c171132e237b4