### PR TITLE
fix: refine nomenclature search and mapping

### DIFF
--- a/src/pages/references/Nomenclature.tsx
+++ b/src/pages/references/Nomenclature.tsx
@@ -1,4 +1,4 @@
-import { type Key, useEffect, useMemo, useRef, useState } from 'react'
+import { type Key, useEffect, useRef, useState } from 'react'
 import {
   App,
   AutoComplete,
@@ -49,10 +49,14 @@ export default function Nomenclature() {
   const importAbortRef = useRef(false)
 
   const { data: materials = [], isLoading, refetch } = useQuery({
-    queryKey: ['nomenclature'],
+    queryKey: ['nomenclature', searchText],
     queryFn: async () => {
       if (!supabase) return []
-      const { data: mats, error } = await supabase.from('nomenclature').select('*').order('name')
+      let query = supabase.from('nomenclature').select('*').order('name')
+      if (searchText) {
+        query = query.ilike('name', `%${searchText}%`)
+      }
+      const { data: mats, error } = await query
       if (error) throw error
       const { data: prices } = await supabase
         .from('material_prices')
@@ -64,20 +68,14 @@ export default function Nomenclature() {
         entry.count += 1
         priceMap.set(p.material_id, entry)
       })
-      return ((mats as Material[]) ?? []).map(m => ({
+      return ((mats as Material[]) ?? []).map((m) => ({
         ...m,
         average_price: priceMap.has(m.id)
           ? Math.round(priceMap.get(m.id)!.sum / priceMap.get(m.id)!.count)
-          : null
+          : null,
       }))
-    }
+    },
   })
-
-  const filteredData = useMemo(
-    () =>
-      materials.filter(m => m.name.toLowerCase().startsWith(searchText.toLowerCase())),
-    [materials, searchText]
-  )
 
   const formatPrice = (value: number | null) =>
     value !== null && value !== undefined
@@ -134,7 +132,7 @@ export default function Nomenclature() {
     const { data } = await supabase
       .from('nomenclature')
       .select('name')
-      .ilike('name', `${value}%`)
+      .ilike('name', `%${value}%`)
       .limit(20)
     setAutoOptions((data ?? []).map((d: { name: string }) => ({ value: d.name })))
   }
@@ -393,10 +391,11 @@ export default function Nomenclature() {
         </Button>
       </div>
       <Table<Material>
-        dataSource={filteredData}
+        dataSource={materials}
         columns={columns}
         rowKey="id"
         loading={isLoading}
+        pagination={{ pageSize: 100 }}
       />
       <Modal
         open={modalMode !== null}


### PR DESCRIPTION
## Summary
- search nomenclature list by any substring with 100-row pages
- widen chessboard nomenclature dropdown to fit labels and persist selections

## Testing
- `npx eslint src/pages/references/Nomenclature.tsx src/pages/documents/Chessboard.tsx`
- `npm run lint` (fails: Unexpected any in other files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b15cdba074832e82f5d7ca12858110