### PR TITLE
fix: уменьшение высоты строк шахматки

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -69,3 +69,8 @@ body[data-theme='dark'] {
 .row-purple * {
   color: #000000 !important;
 }
+
+.chessboard-table .ant-table-cell {
+  padding-top: 2px !important;
+  padding-bottom: 2px !important;
+}

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -2926,7 +2926,7 @@ export default function Chessboard() {
       
       {/* Таблица */}
       {appliedFilters && (
-        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        <div className="chessboard-table" style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
           {mode === 'add' ? (
             <Table<TableRow>
             dataSource={tableRows}


### PR DESCRIPTION
## Summary
- уменьшены отступы в строках таблицы шахматки до 2px

## Testing
- `npm run lint` (fails: Unexpected any...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b16c91e8fc832eb12be3a1ae32f50c