### PR TITLE
fix: use floor mapping quantities in chessboard table

### DIFF
--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -691,24 +691,9 @@ export default function Chessboard() {
         return {
           key: item.id,
           material: item.material ?? '',
-          quantityPd:
-            sumPd !== null
-              ? String(sumPd)
-              : item.quantityPd !== null && item.quantityPd !== undefined
-              ? String(item.quantityPd)
-              : '',
-          quantitySpec:
-            sumSpec !== null
-              ? String(sumSpec)
-              : item.quantitySpec !== null && item.quantitySpec !== undefined
-              ? String(item.quantitySpec)
-              : '',
-          quantityRd:
-            sumRd !== null
-              ? String(sumRd)
-              : item.quantityRd !== null && item.quantityRd !== undefined
-              ? String(item.quantityRd)
-              : '',
+          quantityPd: sumPd !== null ? String(sumPd) : '',
+          quantitySpec: sumSpec !== null ? String(sumSpec) : '',
+          quantityRd: sumRd !== null ? String(sumRd) : '',
           nomenclatureId: getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature_id ?? '',
           nomenclature: getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature?.name ?? '',
           unit: item.units?.name ?? '',


### PR DESCRIPTION
## Summary
- always calculate PD/spec/RD quantities from `chessboard_floor_mapping`

## Testing
- `npm run lint` (fails: Unexpected any etc. in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b17646dfc0832e85b50eed735374a2