### PR TITLE
feat: add supplier mapping import

### DIFF
--- a/src/pages/references/Nomenclature.tsx
+++ b/src/pages/references/Nomenclature.tsx
@@ -29,6 +29,7 @@ interface Material {
 
 interface MaterialExcelRow {
   'Номенклатура': string
+  'Наименование поставщика'?: string
   'Цена'?: number
   'Дата'?: string | number | Date
 }
@@ -254,68 +255,43 @@ export default function Nomenclature() {
     const sheet = workbook.Sheets[workbook.SheetNames[0]]
     const rows: MaterialExcelRow[] = XLSX.utils.sheet_to_json<MaterialExcelRow>(sheet, { defval: null })
     setImportProgress({ processed: 0, total: rows.length })
-    const processedNames = new Set<string>()
+    const chunkSize = 1000
     let successCount = 0
-    for (let i = 0; i < rows.length; i++) {
+    for (let i = 0; i < rows.length; i += chunkSize) {
       if (importAbortRef.current) break
-      const row = rows[i]
-      const rawName = row['Номенклатура']
-      const name = rawName ? rawName.trim() : ''
-      const price = row['Цена']
-      const date = row['Дата']
-      if (!name || processedNames.has(name)) {
-        setImportProgress({ processed: i + 1, total: rows.length })
+      const chunk = rows
+        .slice(i, i + chunkSize)
+        .map((row) => {
+          const priceVal = row['Цена']
+          const price =
+            priceVal !== undefined &&
+            priceVal !== null &&
+            !Number.isNaN(Number(priceVal))
+              ? Number(priceVal)
+              : null
+          const dateVal = row['Дата']
+          const parsedDate = dateVal ? dayjs(dateVal) : null
+          const date = parsedDate && parsedDate.isValid() ? parsedDate.format('YYYY-MM-DD') : null
+          return {
+            name: row['Номенклатура']?.trim(),
+            supplier: row['Наименование поставщика']?.trim(),
+            price,
+            date,
+          }
+        })
+        .filter((r) => r.name)
+      if (chunk.length === 0) {
+        setImportProgress({ processed: Math.min(i + chunkSize, rows.length), total: rows.length })
         continue
       }
-      processedNames.add(name)
-      let materialId: string
-      let insertedSomething = false
-      const { data: existing } = await supabase
-        .from('nomenclature')
-        .select('id')
-        .eq('name', name)
-        .maybeSingle()
-      if (existing) {
-        materialId = existing.id
+      const { data: inserted, error } = await supabase.rpc('import_nomenclature', { rows: chunk })
+      if (error) {
+        console.error(error)
+        message.error('Ошибка импорта данных')
       } else {
-        const { data: inserted, error } = await supabase
-          .from('nomenclature')
-          .insert({ name })
-          .select()
-          .single()
-        if (error) {
-          setImportProgress({ processed: i + 1, total: rows.length })
-          continue
-        }
-        materialId = inserted!.id
-        insertedSomething = true
+        successCount += inserted || 0
       }
-      if (price !== null && price !== undefined) {
-        const purchaseDate = date ? dayjs(date).format('YYYY-MM-DD') : dayjs().format('YYYY-MM-DD')
-        const { data: existingPrice } = await supabase
-          .from('material_prices')
-          .select('id')
-          .eq('material_id', materialId)
-          .eq('price', Number(price))
-          .eq('purchase_date', purchaseDate)
-          .maybeSingle()
-        if (existingPrice) {
-          await supabase
-            .from('material_prices')
-            .update({ price: Number(price), purchase_date: purchaseDate })
-            .eq('id', existingPrice.id)
-          insertedSomething = true
-        } else {
-          await supabase.from('material_prices').insert({
-            material_id: materialId,
-            price: Number(price),
-            purchase_date: purchaseDate
-          })
-          insertedSomething = true
-        }
-      }
-      if (insertedSomething) successCount++
-      setImportProgress({ processed: i + 1, total: rows.length })
+      setImportProgress({ processed: Math.min(i + chunkSize, rows.length), total: rows.length })
     }
     if (importAbortRef.current) {
       importAbortRef.current = false
@@ -551,7 +527,7 @@ export default function Nomenclature() {
       >
         <Space direction="vertical" style={{ width: '100%' }}>
           <div>
-            <p>Поля файла: Номенклатура, Цена, Дата</p>
+            <p>Поля файла: Номенклатура, Наименование поставщика, Цена, Дата</p>
             <Upload
               beforeUpload={handleImport}
               showUploadList={false}

--- a/supabase.sql
+++ b/supabase.sql
@@ -307,6 +307,8 @@ create table if not exists nomenclature (
   updated_at timestamptz default now()
 );
 
+create unique index if not exists nomenclature_name_key on nomenclature(name);
+
 create table if not exists material_prices (
   id uuid primary key default gen_random_uuid(),
   material_id uuid references nomenclature(id) on delete cascade,
@@ -317,6 +319,17 @@ create table if not exists material_prices (
   unique (material_id, price, purchase_date)
 );
 
+-- Remove duplicate price entries before adding unique constraint
+delete from material_prices mp
+using material_prices mp2
+where mp.id > mp2.id
+  and mp.material_id = mp2.material_id
+  and mp.price = mp2.price
+  and mp.purchase_date = mp2.purchase_date;
+
+create unique index if not exists material_prices_material_id_price_purchase_date_key
+  on material_prices(material_id, price, purchase_date);
+
 create index if not exists idx_material_prices_material_id on material_prices(material_id);
 
 grant all on table nomenclature to anon;
@@ -326,3 +339,77 @@ grant all on table nomenclature to service_role;
 grant all on table material_prices to anon;
 grant all on table material_prices to authenticated;
 grant all on table material_prices to service_role;
+
+create table if not exists supplier_names (
+  id uuid primary key default gen_random_uuid(),
+  name text unique not null
+);
+
+create unique index if not exists supplier_names_name_key on supplier_names(name);
+
+create table if not exists nomenclature_supplier_mapping (
+  nomenclature_id uuid references nomenclature(id) on delete cascade,
+  supplier_id uuid references supplier_names(id) on delete cascade,
+  primary key (nomenclature_id, supplier_id)
+);
+
+grant all on table supplier_names to anon;
+grant all on table supplier_names to authenticated;
+grant all on table supplier_names to service_role;
+
+grant all on table nomenclature_supplier_mapping to anon;
+grant all on table nomenclature_supplier_mapping to authenticated;
+grant all on table nomenclature_supplier_mapping to service_role;
+
+create or replace function import_nomenclature(rows jsonb)
+returns bigint
+language plpgsql
+as $$
+declare
+  inserted bigint;
+begin
+  insert into nomenclature(name)
+  select distinct value->>'name'
+  from jsonb_array_elements(rows) as value
+  where trim(coalesce(value->>'name', '')) <> ''
+  on conflict (name) do nothing;
+
+  insert into supplier_names(name)
+  select distinct value->>'supplier'
+  from jsonb_array_elements(rows) as value
+  where trim(coalesce(value->>'supplier', '')) <> ''
+  on conflict (name) do nothing;
+
+  insert into nomenclature_supplier_mapping(nomenclature_id, supplier_id)
+  select n.id, s.id
+  from (
+    select distinct value->>'name' as name, value->>'supplier' as supplier
+    from jsonb_array_elements(rows) as value
+    where trim(coalesce(value->>'name', '')) <> ''
+      and trim(coalesce(value->>'supplier', '')) <> ''
+  ) as t
+  join nomenclature n on n.name = t.name
+  join supplier_names s on s.name = t.supplier
+  on conflict do nothing;
+
+  insert into material_prices(material_id, price, purchase_date)
+  select n.id,
+         (value->>'price')::numeric,
+         coalesce(
+           nullif(value->>'date', '')::date,
+           current_date)
+  from jsonb_array_elements(rows) as value
+  join nomenclature n on n.name = value->>'name'
+  where trim(coalesce(value->>'price', '')) <> ''
+    and (value->>'price') ~ '^\d+(\.\d+)?$'
+    and (
+      value->>'date' is null
+      or value->>'date' = ''
+      or value->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+    )
+  on conflict (material_id, price, purchase_date) do nothing;
+
+  get diagnostics inserted = row_count;
+  return inserted;
+end;
+$$;

--- a/supabase/migrations/create_nomenclature.sql
+++ b/supabase/migrations/create_nomenclature.sql
@@ -5,6 +5,8 @@ create table if not exists public.nomenclature (
   updated_at timestamptz default now()
 );
 
+create unique index if not exists nomenclature_name_key on public.nomenclature(name);
+
 create table if not exists public.material_prices (
   id uuid primary key default gen_random_uuid(),
   material_id uuid references public.nomenclature(id) on delete cascade,
@@ -15,6 +17,17 @@ create table if not exists public.material_prices (
   unique (material_id, price, purchase_date)
 );
 
+-- Remove duplicate price entries before adding unique constraint
+delete from public.material_prices mp
+using public.material_prices mp2
+where mp.id > mp2.id
+  and mp.material_id = mp2.material_id
+  and mp.price = mp2.price
+  and mp.purchase_date = mp2.purchase_date;
+
+create unique index if not exists material_prices_material_id_price_purchase_date_key
+  on public.material_prices(material_id, price, purchase_date);
+
 create index if not exists idx_material_prices_material_id on public.material_prices(material_id);
 
 grant all on table public.nomenclature to anon;
@@ -24,3 +37,77 @@ grant all on table public.nomenclature to service_role;
 grant all on table public.material_prices to anon;
 grant all on table public.material_prices to authenticated;
 grant all on table public.material_prices to service_role;
+
+create table if not exists public.supplier_names (
+  id uuid primary key default gen_random_uuid(),
+  name text unique not null
+);
+
+create unique index if not exists supplier_names_name_key on public.supplier_names(name);
+
+create table if not exists public.nomenclature_supplier_mapping (
+  nomenclature_id uuid references public.nomenclature(id) on delete cascade,
+  supplier_id uuid references public.supplier_names(id) on delete cascade,
+  primary key (nomenclature_id, supplier_id)
+);
+
+grant all on table public.supplier_names to anon;
+grant all on table public.supplier_names to authenticated;
+grant all on table public.supplier_names to service_role;
+
+grant all on table public.nomenclature_supplier_mapping to anon;
+grant all on table public.nomenclature_supplier_mapping to authenticated;
+grant all on table public.nomenclature_supplier_mapping to service_role;
+
+create or replace function public.import_nomenclature(rows jsonb)
+returns bigint
+language plpgsql
+as $$
+declare
+  inserted bigint;
+begin
+  insert into public.nomenclature(name)
+  select distinct value->>'name'
+  from jsonb_array_elements(rows) as value
+  where trim(coalesce(value->>'name', '')) <> ''
+  on conflict (name) do nothing;
+
+  insert into public.supplier_names(name)
+  select distinct value->>'supplier'
+  from jsonb_array_elements(rows) as value
+  where trim(coalesce(value->>'supplier', '')) <> ''
+  on conflict (name) do nothing;
+
+  insert into public.nomenclature_supplier_mapping(nomenclature_id, supplier_id)
+  select n.id, s.id
+  from (
+    select distinct value->>'name' as name, value->>'supplier' as supplier
+    from jsonb_array_elements(rows) as value
+    where trim(coalesce(value->>'name', '')) <> ''
+      and trim(coalesce(value->>'supplier', '')) <> ''
+  ) as t
+  join public.nomenclature n on n.name = t.name
+  join public.supplier_names s on s.name = t.supplier
+  on conflict do nothing;
+
+  insert into public.material_prices(material_id, price, purchase_date)
+  select n.id,
+         (value->>'price')::numeric,
+         coalesce(
+           nullif(value->>'date', '')::date,
+           current_date)
+  from jsonb_array_elements(rows) as value
+  join public.nomenclature n on n.name = value->>'name'
+  where trim(coalesce(value->>'price', '')) <> ''
+    and (value->>'price') ~ '^\d+(\.\d+)?$'
+    and (
+      value->>'date' is null
+      or value->>'date' = ''
+      or value->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+    )
+  on conflict (material_id, price, purchase_date) do nothing;
+
+  get diagnostics inserted = row_count;
+  return inserted;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add supplier name and mapping tables
- import nomenclature with suppliers via server-side function
- validate excel data to avoid invalid price/date and report RPC errors
- ensure unique indexes for names and prices to allow ON CONFLICT
- remove duplicate material price records before adding unique index

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc. in unrelated files)*
- `npx eslint src/pages/references/Nomenclature.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1937ad8a8832e800d8471e2011f69