### PR TITLE
feat: add dark theme logo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import Disk from './pages/admin/Disk'
 import PortalHeader from './components/PortalHeader'
 import TestTableStructure from './pages/TestTableStructure'
 import logoLight from './logo_light.svg'
+import logoDark from './logo_dark_1.svg'
 
 const { Sider, Content } = Layout
 
@@ -463,7 +464,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             }}
           >
             <img
-              src={logoLight}
+              src={isDark ? logoDark : logoLight}
               alt="BlueprintFlow logo"
               style={{ width: '72%', height: 'auto' }}
             />


### PR DESCRIPTION
## Summary
- switch to alternate logo for dark mode

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1bfea80fc832eba6813e4ea59aa43