### PR TITLE
feat: add supplier column to chessboard mapping

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -54,8 +54,7 @@ create table if not exists chessboard (
 create table if not exists chessboard_nomenclature_mapping (
   chessboard_id uuid references chessboard on delete cascade,
   nomenclature_id uuid references nomenclature on delete cascade,
-  created_at timestamptz default now(),
-  updated_at timestamptz default now(),
+  supplier_name text,
   primary key (chessboard_id, nomenclature_id)
 );
 

--- a/supabase/migrations/alter_chessboard_nomenclature_mapping_add_supplier.sql
+++ b/supabase/migrations/alter_chessboard_nomenclature_mapping_add_supplier.sql
@@ -1,0 +1,3 @@
+alter table public.chessboard_nomenclature_mapping add column supplier_name text;
+alter table public.chessboard_nomenclature_mapping drop column if exists created_at;
+alter table public.chessboard_nomenclature_mapping drop column if exists updated_at;

--- a/supabase/migrations/create_chessboard_nomenclature_mapping.sql
+++ b/supabase/migrations/create_chessboard_nomenclature_mapping.sql
@@ -1,8 +1,7 @@
 create table if not exists public.chessboard_nomenclature_mapping (
   chessboard_id uuid not null references public.chessboard(id) on delete cascade,
   nomenclature_id uuid not null references public.nomenclature(id) on delete cascade,
-  created_at timestamptz default now(),
-  updated_at timestamptz default now(),
+  supplier_name text,
   primary key (chessboard_id, nomenclature_id)
 );
 


### PR DESCRIPTION
## Summary
- store supplier name directly in chessboard_nomenclature_mapping
- load and save supplier names from mapping table
- remove timestamps from chessboard_nomenclature_mapping

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2b19d8b4c832eba3d9a9783476930