### PR TITLE
feat: add interface scaling options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import { Layout, Menu, Popover, Switch } from 'antd'
 import { Link, Route, Routes, useNavigate, useLocation } from 'react-router-dom'
-import { MoonOutlined } from '@ant-design/icons'
+import { MoonOutlined, CheckOutlined } from '@ant-design/icons'
 import Dashboard from './pages/Dashboard'
 import Documents from './pages/Documents'
 import Chessboard from './pages/documents/Chessboard'
@@ -24,6 +24,7 @@ import TestTableStructure from './pages/TestTableStructure'
 
 import PortalSettings from './pages/admin/PortalSettings'
 import { useLogo } from './shared/contexts/LogoContext'
+import { useScale } from './shared/contexts/ScaleContext'
 
 
 const { Sider, Content } = Layout
@@ -39,6 +40,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const { lightLogo, darkLogo } = useLogo()
+  const { scale, setScale } = useScale()
 
   // Автоматически открываем нужные подменю при смене роута
   useEffect(() => {
@@ -240,6 +242,30 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
     </div>
   )
 
+  const scaleSubmenu = (
+    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>
+      {[
+        { value: 0.7, label: '70%' },
+        { value: 0.8, label: '80%' },
+        { value: 0.9, label: '90%' },
+        { value: 1, label: '100%' }
+      ].map(({ value, label }) => (
+        <div
+          key={label}
+          style={menuItemStyle}
+          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)')}
+          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+          onClick={() => setScale(value)}
+        >
+          <span style={linkStyle}>
+            {scale === value && <CheckOutlined style={{ marginRight: 8 }} />}
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+
   const adminSubmenu = (
     <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>
       <div 
@@ -277,6 +303,15 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Link to="/admin/portal-settings" style={linkStyle}>
           Настройка портала
         </Link>
+      </div>
+      <div
+        style={menuItemStyle}
+        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
+        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+      >
+        <Popover content={scaleSubmenu} placement="rightTop" trigger="hover" overlayStyle={{ paddingLeft: 10 }} arrow={false}>
+          <span style={linkStyle}>Масштаб</span>
+        </Popover>
       </div>
       <div
         style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
@@ -351,6 +386,16 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         {
           key: 'portal-settings',
           label: <Link to="/admin/portal-settings">Настройка портала</Link>
+        },
+        {
+          key: 'scale',
+          label: 'Масштаб',
+          children: [
+            { key: 'scale-70', label: '70%', onClick: () => setScale(0.7), icon: scale === 0.7 ? <CheckOutlined /> : undefined },
+            { key: 'scale-80', label: '80%', onClick: () => setScale(0.8), icon: scale === 0.8 ? <CheckOutlined /> : undefined },
+            { key: 'scale-90', label: '90%', onClick: () => setScale(0.9), icon: scale === 0.9 ? <CheckOutlined /> : undefined },
+            { key: 'scale-100', label: '100%', onClick: () => setScale(1), icon: scale === 1 ? <CheckOutlined /> : undefined },
+          ],
         },
         {
           key: 'theme-toggle',

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+:root {
+  --app-scale: 1;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
@@ -13,6 +17,13 @@ body[data-theme='light'] {
 body[data-theme='dark'] {
   --menu-bg: #555555;
   --menu-color: #ffffff;
+}
+
+#root {
+  transform-origin: top left;
+  transform: scale(var(--app-scale));
+  width: calc(100% / var(--app-scale));
+  height: calc(100% / var(--app-scale));
 }
 
 .ant-menu-dark,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
 import { LogoProvider } from './shared/contexts/LogoContext'
+import { ScaleProvider } from './shared/contexts/ScaleContext'
 
 unstableSetRender((node, container) => {
   const root = createRoot(container)
@@ -62,9 +63,11 @@ export function Root() {
       <AntdApp>
         <QueryClientProvider client={queryClient}>
           <LogoProvider>
-            <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-              <App isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
-            </BrowserRouter>
+            <ScaleProvider>
+              <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+                <App isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
+              </BrowserRouter>
+            </ScaleProvider>
           </LogoProvider>
         </QueryClientProvider>
       </AntdApp>

--- a/src/shared/contexts/ScaleContext.tsx
+++ b/src/shared/contexts/ScaleContext.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+
+interface ScaleContextType {
+  scale: number
+  setScale: (value: number) => void
+}
+
+const ScaleContext = createContext<ScaleContextType | undefined>(undefined)
+
+export function ScaleProvider({ children }: { children: ReactNode }) {
+  const [scale, setScaleState] = useState<number>(() => {
+    const saved = localStorage.getItem('blueprintflow-scale')
+    return saved ? Number(saved) : 1
+  })
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--app-scale', String(scale))
+    localStorage.setItem('blueprintflow-scale', String(scale))
+  }, [scale])
+
+  const setScale = (value: number) => {
+    setScaleState(value)
+  }
+
+  return (
+    <ScaleContext.Provider value={{ scale, setScale }}>
+      {children}
+    </ScaleContext.Provider>
+  )
+}
+
+export function useScale() {
+  const context = useContext(ScaleContext)
+  if (!context) {
+    throw new Error('useScale must be used within ScaleProvider')
+  }
+  return context
+}
+


### PR DESCRIPTION
## Summary
- add context for storing UI scale
- add Admin menu to change scale between 70-100%
- apply global CSS transform based on selected scale

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d55d800c832e905aa895e29f469a