### PR TITLE
feat: add interface scaling options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react'
-import { Layout, Menu, Popover, Switch } from 'antd'
+import { Layout, Menu, Popover, Switch, Select } from 'antd'
 import { Link, Route, Routes, useNavigate, useLocation } from 'react-router-dom'
 import { MoonOutlined } from '@ant-design/icons'
 import Dashboard from './pages/Dashboard'
@@ -24,6 +24,7 @@ import TestTableStructure from './pages/TestTableStructure'
 
 import PortalSettings from './pages/admin/PortalSettings'
 import { useLogo } from './shared/contexts/LogoContext'
+import { useScale } from './shared/contexts/ScaleContext'
 
 
 const { Sider, Content } = Layout
@@ -39,6 +40,13 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const { lightLogo, darkLogo } = useLogo()
+  const { scale, setScale } = useScale()
+  const scaleOptions = [
+    { value: 0.7, label: '70%' },
+    { value: 0.8, label: '80%' },
+    { value: 0.9, label: '90%' },
+    { value: 1, label: '100%' }
+  ]
 
   // Автоматически открываем нужные подменю при смене роута
   useEffect(() => {
@@ -283,6 +291,20 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
         onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
       >
+        <span style={linkStyle}>Масштаб</span>
+        <Select<number>
+          value={scale}
+          onChange={(value) => setScale(value)}
+          options={scaleOptions}
+          style={{ width: 80 }}
+          size="small"
+        />
+      </div>
+      <div
+        style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
+        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+      >
         <span style={linkStyle}>Тема</span>
         <Switch
           checked={isDark}
@@ -351,6 +373,21 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         {
           key: 'portal-settings',
           label: <Link to="/admin/portal-settings">Настройка портала</Link>
+        },
+        {
+          key: 'scale',
+          label: (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span>Масштаб</span>
+              <Select<number>
+                value={scale}
+                onChange={(value) => setScale(value)}
+                options={scaleOptions}
+                style={{ width: 80 }}
+                size="small"
+              />
+            </div>
+          ),
         },
         {
           key: 'theme-toggle',
@@ -460,11 +497,12 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           }
         `}
       </style>
-      <Layout style={{ minHeight: '100vh' }}>
+      <Layout style={{ height: '100%' }}>
         <Sider
           theme={isDark ? 'dark' : 'light'}
           style={{
             background: 'var(--menu-bg)',
+            height: '100%'
           }}
           collapsible
           collapsed={collapsed}
@@ -492,7 +530,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             mode="inline"
             inlineCollapsed={collapsed}
             items={items}
-            style={{ background: 'var(--menu-bg)' }}
+            style={{ background: 'var(--menu-bg)', height: '100%' }}
             selectedKeys={[
               location.pathname === '/' ? 'dashboard' :
               location.pathname.startsWith('/documents/chessboard') ? 'chessboard' :
@@ -514,23 +552,27 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             onOpenChange={setOpenKeys}
           />
         </Sider>
-        <Layout>
+        <Layout style={{ height: '100%' }}>
           <PortalHeader isDark={isDark} />
           <Content
             style={{
+              flex: 1,
               margin: 16,
               background: isDark ? '#555555' : '#FCFCFC',
               color: isDark ? '#ffffff' : '#000000',
+              display: 'flex',
+              flexDirection: 'column'
             }}
           >
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/documents" element={<Documents />}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <Routes>
+                  <Route path="/" element={<Dashboard />} />
+                  <Route path="/documents" element={<Documents />}> 
                 <Route path="chessboard" element={<Chessboard />} />
                 <Route path="vor" element={<Vor />} />
                 <Route path="documentation" element={<Documentation />} />
               </Route>
-              <Route path="/references" element={<References />}>
+              <Route path="/references" element={<References />} >
                 <Route index element={<Units />} />
                 <Route path="cost-categories" element={<CostCategories />} />
                 <Route path="projects" element={<Projects />} />
@@ -538,7 +580,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
                 <Route path="rates" element={<Rates />} />
                 <Route path="nomenclature" element={<Nomenclature />} />
               </Route>
-              <Route path="/admin" element={<Admin />}>
+              <Route path="/admin" element={<Admin />} >
                 <Route path="documentation-tags" element={<DocumentationTags />} />
                 <Route path="statuses" element={<Statuses />} />
                 <Route path="disk" element={<Disk />} />
@@ -546,6 +588,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               </Route>
               <Route path="/test-table" element={<TestTableStructure />} />
             </Routes>
+            </div>
           </Content>
         </Layout>
       </Layout>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
+:root {
+  --app-scale: 1;
+}
+
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
@@ -13,6 +22,13 @@ body[data-theme='light'] {
 body[data-theme='dark'] {
   --menu-bg: #555555;
   --menu-color: #ffffff;
+}
+
+#root {
+  transform-origin: top left;
+  transform: scale(var(--app-scale));
+  width: calc(100vw / var(--app-scale));
+  height: calc(100vh / var(--app-scale));
 }
 
 .ant-menu-dark,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
 import { LogoProvider } from './shared/contexts/LogoContext'
+import { ScaleProvider } from './shared/contexts/ScaleContext'
 
 unstableSetRender((node, container) => {
   const root = createRoot(container)
@@ -62,9 +63,11 @@ export function Root() {
       <AntdApp>
         <QueryClientProvider client={queryClient}>
           <LogoProvider>
-            <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-              <App isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
-            </BrowserRouter>
+            <ScaleProvider>
+              <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+                <App isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
+              </BrowserRouter>
+            </ScaleProvider>
           </LogoProvider>
         </QueryClientProvider>
       </AntdApp>

--- a/src/shared/contexts/ScaleContext.tsx
+++ b/src/shared/contexts/ScaleContext.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+
+interface ScaleContextType {
+  scale: number
+  setScale: (value: number) => void
+}
+
+const ScaleContext = createContext<ScaleContextType | undefined>(undefined)
+
+export function ScaleProvider({ children }: { children: ReactNode }) {
+  const [scale, setScaleState] = useState<number>(() => {
+    const saved = localStorage.getItem('blueprintflow-scale')
+    return saved ? Number(saved) : 1
+  })
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--app-scale', String(scale))
+    localStorage.setItem('blueprintflow-scale', String(scale))
+  }, [scale])
+
+  const setScale = (value: number) => {
+    setScaleState(value)
+  }
+
+  return (
+    <ScaleContext.Provider value={{ scale, setScale }}>
+      {children}
+    </ScaleContext.Provider>
+  )
+}
+
+export function useScale() {
+  const context = useContext(ScaleContext)
+  if (!context) {
+    throw new Error('useScale must be used within ScaleProvider')
+  }
+  return context
+}
+


### PR DESCRIPTION
## Summary
- add context for storing UI scale
- add Admin menu to change scale between 70-100%
- apply global CSS transform based on selected scale
- allow choosing scale via dropdown and stretch layout to full height

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d55d800c832e905aa895e29f469a