### PR TITLE
feat: add interface scaling options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react'
-import { Layout, Menu, Popover, Switch } from 'antd'
+import { Layout, Menu, Popover, Switch, Select } from 'antd'
 import { Link, Route, Routes, useNavigate, useLocation } from 'react-router-dom'
 import { MoonOutlined } from '@ant-design/icons'
 import Dashboard from './pages/Dashboard'
@@ -24,6 +24,7 @@ import TestTableStructure from './pages/TestTableStructure'
 
 import PortalSettings from './pages/admin/PortalSettings'
 import { useLogo } from './shared/contexts/LogoContext'
+import { useScale } from './shared/contexts/ScaleContext'
 
 
 const { Sider, Content } = Layout
@@ -39,6 +40,13 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const { lightLogo, darkLogo } = useLogo()
+  const { scale, setScale } = useScale()
+  const scaleOptions = [
+    { value: 0.7, label: '70%' },
+    { value: 0.8, label: '80%' },
+    { value: 0.9, label: '90%' },
+    { value: 1, label: '100%' }
+  ]
 
   // Автоматически открываем нужные подменю при смене роута
   useEffect(() => {
@@ -57,9 +65,9 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   
   const LetterIcon = ({ letter, children, onClick, isActive }: { letter: string; children?: React.ReactNode; onClick?: () => void; isActive?: boolean }) => {
     const iconContent = (
-      <div style={{ 
-        display: 'flex', 
-        alignItems: 'center', 
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
         height: '100%',
@@ -71,23 +79,21 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
       }}>
         <div
           style={{
-            width: 32,
-            height: 32,
-            borderRadius: 4,
-              border: `1px solid ${isActive
-                ? '#a69ead'
-                : 'transparent'}`,
+            width: 32 * scale,
+            height: 32 * scale,
+            borderRadius: 4 * scale,
+            border: `1px solid ${isActive ? '#a69ead' : 'transparent'}`,
             boxShadow: 'none',
             backgroundColor: isActive
               ? isDark ? 'rgba(166, 158, 173, 0.1)' : 'rgba(166, 158, 173, 0.05)'
               : 'transparent',
-              color: isActive
-                ? '#a69ead'
-                : isDark ? '#ffffff' : '#000000',
+            color: isActive
+              ? '#a69ead'
+              : isDark ? '#ffffff' : '#000000',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            fontSize: 16,
+            fontSize: 16 * scale,
             fontWeight: 600,
             cursor: 'pointer',
             transition: 'background-color 0.3s, color 0.3s',
@@ -119,7 +125,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           content={children}
           placement="rightTop"
           trigger="hover"
-          overlayStyle={{ paddingLeft: 10 }}
+          overlayStyle={{ paddingLeft: 10 * scale }}
           arrow={false}
           align={{
             offset: [0, -16]
@@ -134,16 +140,16 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   }
 
   const menuItemStyle: React.CSSProperties = {
-    paddingLeft: '12px',
-    paddingRight: '12px',
-    minWidth: '180px',
+    paddingLeft: 12 * scale,
+    paddingRight: 12 * scale,
+    minWidth: 180 * scale,
     transition: 'background-color 0.3s',
   }
 
   const linkStyle: React.CSSProperties = {
     color: isDark ? '#fff' : '#000',
     display: 'block',
-    padding: '5px 0',
+    padding: `${5 * scale}px 0`,
     textDecoration: 'none',
   }
 
@@ -159,7 +165,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   )
 
   const documentsSubmenu = (
-    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>
+    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4 * scale, padding: `${4 * scale}px 0` }}>
       <div 
         style={menuItemStyle}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
@@ -182,7 +188,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   )
 
   const referencesSubmenu = (
-    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>
+    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4 * scale, padding: `${4 * scale}px 0` }}>
       <div 
         style={menuItemStyle}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
@@ -241,7 +247,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
   )
 
   const adminSubmenu = (
-    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4, padding: '4px 0' }}>
+    <div style={{ backgroundColor: isDark ? '#1f1f1f' : '#fff', borderRadius: 4 * scale, padding: `${4 * scale}px 0` }}>
       <div 
         style={menuItemStyle}
         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
@@ -277,6 +283,20 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         <Link to="/admin/portal-settings" style={linkStyle}>
           Настройка портала
         </Link>
+      </div>
+      <div
+        style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
+        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+      >
+        <span style={linkStyle}>Масштаб</span>
+        <Select<number>
+          value={scale}
+          onChange={(value) => setScale(value)}
+          options={scaleOptions}
+          style={{ width: 80 * scale }}
+          size="small"
+        />
       </div>
       <div
         style={{ ...menuItemStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
@@ -353,6 +373,21 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           label: <Link to="/admin/portal-settings">Настройка портала</Link>
         },
         {
+          key: 'scale',
+          label: (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span>Масштаб</span>
+              <Select<number>
+                value={scale}
+                onChange={(value) => setScale(value)}
+                options={scaleOptions}
+                style={{ width: 80 * scale }}
+                size="small"
+              />
+            </div>
+          ),
+        },
+        {
           key: 'theme-toggle',
           label: (
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -392,10 +427,10 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             .ant-menu-submenu .ant-menu-item-selected {
               background-color: ${isDark ? 'rgba(166, 158, 173, 0.1)' : 'rgba(166, 158, 173, 0.05)'} !important;
               border: 1px solid #a69ead !important;
-              border-radius: 4px !important;
+              border-radius: calc(4px * var(--app-scale)) !important;
               box-shadow: none !important;
               color: #a69ead !important;
-              margin: 2px 8px !important;
+              margin: calc(2px * var(--app-scale)) calc(8px * var(--app-scale)) !important;
             }
 
             .ant-menu-submenu .ant-menu-item-selected a {
@@ -427,45 +462,50 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           .ant-menu-item {
             padding: 0 !important;
             margin: 0 !important;
-            height: 40px !important;
-            line-height: 40px !important;
+            height: calc(40px * var(--app-scale)) !important;
+            line-height: calc(40px * var(--app-scale)) !important;
             display: flex !important;
             align-items: center !important;
             justify-content: center !important;
           }
-          
+
           .ant-menu-item-selected {
             padding: 0 !important;
             margin: 0 !important;
-            height: 40px !important;
-            line-height: 40px !important;
+            height: calc(40px * var(--app-scale)) !important;
+            line-height: calc(40px * var(--app-scale)) !important;
             display: flex !important;
             align-items: center !important;
             justify-content: center !important;
             transform: none !important;
           }
-          
+
           .ant-menu:not(.ant-menu-inline-collapsed) > .ant-menu-item {
-            padding-left: 10px !important;
+            padding-left: calc(10px * var(--app-scale)) !important;
             justify-content: flex-start !important;
           }
-          
+
           .ant-menu:not(.ant-menu-inline-collapsed) .ant-menu-submenu-title {
-            padding-left: 10px !important;
+            padding-left: calc(10px * var(--app-scale)) !important;
           }
-          
+
           .ant-menu:not(.ant-menu-inline-collapsed) .ant-menu-submenu .ant-menu-item {
-            padding-left: 20px !important;
+            padding-left: calc(20px * var(--app-scale)) !important;
             justify-content: flex-start !important;
           }
         `}
       </style>
-      <Layout style={{ minHeight: '100vh' }}>
+      <Layout style={{ height: '100vh' }}>
         <Sider
           theme={isDark ? 'dark' : 'light'}
           style={{
             background: 'var(--menu-bg)',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column'
           }}
+          width={200 * scale}
+          collapsedWidth={80 * scale}
           collapsible
           collapsed={collapsed}
           onCollapse={setCollapsed}
@@ -492,7 +532,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             mode="inline"
             inlineCollapsed={collapsed}
             items={items}
-            style={{ background: 'var(--menu-bg)' }}
+            style={{ background: 'var(--menu-bg)', flex: 1 }}
             selectedKeys={[
               location.pathname === '/' ? 'dashboard' :
               location.pathname.startsWith('/documents/chessboard') ? 'chessboard' :
@@ -514,23 +554,28 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
             onOpenChange={setOpenKeys}
           />
         </Sider>
-        <Layout>
+        <Layout style={{ height: '100%', minHeight: 0 }}>
           <PortalHeader isDark={isDark} />
           <Content
             style={{
-              margin: 16,
+              flex: 1,
+              margin: 16 * scale,
               background: isDark ? '#555555' : '#FCFCFC',
               color: isDark ? '#ffffff' : '#000000',
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0
             }}
           >
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/documents" element={<Documents />}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+              <Routes>
+                  <Route path="/" element={<Dashboard />} />
+                  <Route path="/documents" element={<Documents />}> 
                 <Route path="chessboard" element={<Chessboard />} />
                 <Route path="vor" element={<Vor />} />
                 <Route path="documentation" element={<Documentation />} />
               </Route>
-              <Route path="/references" element={<References />}>
+              <Route path="/references" element={<References />} >
                 <Route index element={<Units />} />
                 <Route path="cost-categories" element={<CostCategories />} />
                 <Route path="projects" element={<Projects />} />
@@ -538,7 +583,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
                 <Route path="rates" element={<Rates />} />
                 <Route path="nomenclature" element={<Nomenclature />} />
               </Route>
-              <Route path="/admin" element={<Admin />}>
+              <Route path="/admin" element={<Admin />} >
                 <Route path="documentation-tags" element={<DocumentationTags />} />
                 <Route path="statuses" element={<Statuses />} />
                 <Route path="disk" element={<Disk />} />
@@ -546,6 +591,7 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               </Route>
               <Route path="/test-table" element={<TestTableStructure />} />
             </Routes>
+            </div>
           </Content>
         </Layout>
       </Layout>

--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -3,6 +3,7 @@ import { BellOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
+import { useScale } from '../shared/contexts/ScaleContext';
 
 const { Header } = Layout;
 
@@ -46,6 +47,7 @@ interface PortalHeaderProps {
 export default function PortalHeader({ isDark }: PortalHeaderProps) {
   const { pathname } = useLocation();
   const [userEmail, setUserEmail] = useState<string>('');
+  const { scale } = useScale();
 
   useEffect(() => {
     if (!supabase) return;
@@ -58,25 +60,26 @@ export default function PortalHeader({ isDark }: PortalHeaderProps) {
     <Header
       style={{
         background: isDark ? '#555555' : '#f0edf2',
-        padding: '0 16px',
+        padding: `0 ${16 * scale}px`,
+        height: `${64 * scale}px`,
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
         color: isDark ? '#ffffff' : '#000000',
       }}
     >
-        <div style={{ fontSize: '16px', fontWeight: 500 }}>
+        <div style={{ fontSize: `${16 * scale}px`, fontWeight: 500 }}>
           <span style={{ fontWeight: 600 }}>BlueprintFlow</span>
           {getPageTitle(pathname) && (
             <>
-              <span style={{ margin: '0 8px', opacity: 0.5 }}>/</span>
+              <span style={{ margin: `0 ${8 * scale}px`, opacity: 0.5 }}>/</span>
               <span>{getPageTitle(pathname)}</span>
             </>
           )}
         </div>
-      <Space size="middle">
+      <Space size={16 * scale}>
         <Button type="text" icon={<BellOutlined />} />
-        <Space>
+        <Space size={4 * scale}>
           <UserOutlined />
           <span>{userEmail}</span>
         </Space>

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,23 @@
+:root {
+  --app-scale: 1;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+html {
+  font-size: calc(16px * var(--app-scale));
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
   background-color: #FCFCFC;
   color: #000;
+  overflow: hidden;
 }
 
 body[data-theme='light'] {
@@ -13,6 +28,11 @@ body[data-theme='light'] {
 body[data-theme='dark'] {
   --menu-bg: #555555;
   --menu-color: #ffffff;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
 }
 
 .ant-menu-dark,
@@ -70,7 +90,11 @@ body[data-theme='dark'] {
   color: #000000 !important;
 }
 
+.ant-table {
+  font-size: calc(14px * var(--app-scale));
+}
+
 .chessboard-table .ant-table-cell {
-  padding-top: 2px !important;
-  padding-bottom: 2px !important;
+  padding-top: calc(2px * var(--app-scale)) !important;
+  padding-bottom: calc(2px * var(--app-scale)) !important;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import 'antd/dist/reset.css'
 import './index.css'
 import App from './App.tsx'
 import { LogoProvider } from './shared/contexts/LogoContext'
+import { ScaleProvider, useScale } from './shared/contexts/ScaleContext'
 
 unstableSetRender((node, container) => {
   const root = createRoot(container)
@@ -24,6 +25,16 @@ export function Root() {
     return savedTheme === 'dark'
   })
 
+  return (
+    <ScaleProvider>
+      <ConfiguredApp isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
+    </ScaleProvider>
+  )
+}
+
+function ConfiguredApp({ isDark, toggleTheme }: { isDark: boolean; toggleTheme: () => void }) {
+  const { scale } = useScale()
+
   useEffect(() => {
     document.body.style.backgroundColor = isDark ? '#555555' : '#FCFCFC'
     document.body.style.color = isDark ? '#ffffff' : '#000000'
@@ -33,37 +44,27 @@ export function Root() {
 
   return (
     <ConfigProvider
-      theme={
-        isDark
-          ? {
-              algorithm: theme.darkAlgorithm,
-              token: {
-                colorPrimary: '#a69ead',
-                colorInfo: '#a69ead',
-                colorLink: '#a69ead',
-                colorBgLayout: '#555555',
-                colorBgContainer: '#555555',
-                colorText: '#ffffff',
-              },
-            }
-          : {
-              algorithm: theme.defaultAlgorithm,
-              token: {
-                colorPrimary: '#a69ead',
-                colorInfo: '#a69ead',
-                colorLink: '#a69ead',
-                colorBgLayout: '#FCFCFC',
-                colorBgContainer: '#FCFCFC',
-                colorText: '#000000',
-              },
-            }
-      }
+      theme={{
+        algorithm: isDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#a69ead',
+          colorInfo: '#a69ead',
+          colorLink: '#a69ead',
+          colorBgLayout: isDark ? '#555555' : '#FCFCFC',
+          colorBgContainer: isDark ? '#555555' : '#FCFCFC',
+          colorText: isDark ? '#ffffff' : '#000000',
+          fontSize: 14 * scale,
+          controlHeight: 32 * scale,
+          sizeUnit: 4 * scale,
+          sizeStep: 4 * scale,
+        },
+      }}
     >
       <AntdApp>
         <QueryClientProvider client={queryClient}>
           <LogoProvider>
             <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-              <App isDark={isDark} toggleTheme={() => setIsDark((prev) => !prev)} />
+              <App isDark={isDark} toggleTheme={toggleTheme} />
             </BrowserRouter>
           </LogoProvider>
         </QueryClientProvider>

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -7,6 +7,7 @@ import * as XLSX from 'xlsx'
 import { supabase } from '../../lib/supabase'
 import { documentationApi } from '@/entities/documentation'
 import { documentationTagsApi } from '@/entities/documentation-tags'
+import { useScale } from '@/shared/contexts/ScaleContext'
 
 type RowColor = '' | 'green' | 'yellow' | 'blue' | 'red'
 
@@ -290,6 +291,7 @@ const collapseMap: Record<string, HiddenColKey> = {
 
 export default function Chessboard() {
   const { message } = App.useApp()
+  const { scale } = useScale()
   
   // Диагностика скролла
   useEffect(() => {
@@ -2853,12 +2855,13 @@ export default function Chessboard() {
   }, [viewRows, allColumns])
 
   return (
-    <div style={{ 
-      height: 'calc(100vh - 96px)', 
-      display: 'flex', 
+    <div style={{
+      flex: 1,
+      display: 'flex',
       flexDirection: 'column',
       overflow: 'hidden',
-      position: 'relative'
+      position: 'relative',
+      minHeight: 0
     }}>
       <div style={{ flexShrink: 0, paddingBottom: 16 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
@@ -2866,7 +2869,7 @@ export default function Chessboard() {
             <Text style={{ fontSize: '16px' }}>Объект:</Text>
             <Select
               placeholder="Выберите проект"
-              style={{ width: 280 }}
+              style={{ width: 280 * scale }}
               size="large"
               allowClear
               value={filters.projectId}
@@ -3131,7 +3134,7 @@ export default function Chessboard() {
       
       {/* Таблица */}
       {appliedFilters && (
-        <div className="chessboard-table" style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        <div className="chessboard-table" style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
           {mode === 'add' ? (
             <Table<TableRow>
             dataSource={tableRows}
@@ -3139,9 +3142,9 @@ export default function Chessboard() {
             pagination={false}
             rowKey="key"
             sticky
-            scroll={{ 
+            scroll={{
               x: 'max-content',
-              y: 'calc(100vh - 300px)'
+              y: '100%'
             }}
             rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
           />
@@ -3152,9 +3155,9 @@ export default function Chessboard() {
             pagination={false}
             rowKey="key"
             sticky
-            scroll={{ 
+            scroll={{
               x: 'max-content',
-              y: 'calc(100vh - 300px)'
+              y: '100%'
             }}
             rowClassName={(record) => {
               const color = editingRows[record.key]?.color ?? record.color

--- a/src/pages/references/Documentation.tsx
+++ b/src/pages/references/Documentation.tsx
@@ -52,6 +52,7 @@ import {
 } from '@/entities/documentation'
 import { documentationTagsApi } from '@/entities/documentation-tags'
 import { supabase } from '@/lib/supabase'
+import { useScale } from '@/shared/contexts/ScaleContext'
 import { DOCUMENT_STAGES } from '@/shared/types'
 import ConflictResolutionDialog from '@/components/ConflictResolutionDialog'
 
@@ -103,6 +104,7 @@ const getColumnSettings = (): DocumentationColumnSettings => {
 
 export default function Documentation() {
   const { message } = App.useApp()
+  const { scale } = useScale()
   const queryClient = useQueryClient()
   const [filters, setFilters] = useState<DocumentationFilters>({})
   const [appliedFilters, setAppliedFilters] = useState<DocumentationFilters>({})
@@ -1417,11 +1419,12 @@ export default function Documentation() {
   }, [newRows, documentation])
 
   return (
-    <div style={{ 
-      height: 'calc(100vh - 96px)',
+    <div style={{
+      flex: 1,
       display: 'flex',
       flexDirection: 'column',
-      overflow: 'hidden'
+      overflow: 'hidden',
+      minHeight: 0
     }}>
       <div style={{ flexShrink: 0, paddingBottom: 16 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
@@ -1429,11 +1432,11 @@ export default function Documentation() {
             <Text style={{ fontSize: '16px' }}>Проект:</Text>
             <Select
               placeholder="Выберите проект"
-              style={{ width: 280 }}
+              style={{ width: 280 * scale }}
               size="large"
               value={filters.project_id}
               onChange={(value) => setFilters({ ...filters, project_id: value, block_id: undefined })}
-              options={projects?.map((p) => ({ 
+              options={projects?.map((p) => ({
                 value: p.id, 
                 label: <span style={{ fontWeight: 'bold' }}>{p.name}</span> 
               })) ?? []}
@@ -1724,9 +1727,9 @@ export default function Documentation() {
               },
             }}
             sticky
-            scroll={{ 
+            scroll={{
               x: 'max-content',
-              y: 'calc(100vh - 300px)'
+              y: '100%'
             }}
           // TODO: раскомментировать после добавления колонки color в БД
           /*onRow={(record: DocumentationTableRow) => ({

--- a/src/pages/references/Rates.tsx
+++ b/src/pages/references/Rates.tsx
@@ -38,6 +38,7 @@ import type { UploadFile } from 'antd/es/upload'
 import * as XLSX from 'xlsx'
 import { ratesApi, type RateWithRelations, type RateExcelRow, type RateFormData } from '@/entities/rates'
 import { supabase } from '@/lib/supabase'
+import { useScale } from '@/shared/contexts/ScaleContext'
 // import ConflictResolutionDialog from '@/components/ConflictResolutionDialog'
 
 const { Text, Title } = Typography
@@ -70,6 +71,7 @@ const defaultColumnOrder = ['work_name', 'work_set', 'cost_category', 'detail_co
 
 export default function Rates() {
   const { message } = App.useApp()
+  const { scale } = useScale()
   const queryClient = useQueryClient()
   const headerRef = useRef<HTMLDivElement>(null)
   const filtersRef = useRef<HTMLDivElement>(null)
@@ -873,11 +875,12 @@ export default function Rates() {
   const hasUnsavedChanges = newRows.length > 0 || Object.keys(editingRows).length > 0
 
   return (
-    <div style={{ 
-      height: 'calc(100vh - 96px)', 
-      display: 'flex', 
+    <div style={{
+      flex: 1,
+      display: 'flex',
       flexDirection: 'column',
-      overflow: 'hidden'
+      overflow: 'hidden',
+      minHeight: 0
     }}>
       <div style={{ flexShrink: 0, paddingBottom: 16 }}>
         <Title level={2} style={{ margin: '0 0 16px 0' }}>Расценки</Title>
@@ -896,7 +899,7 @@ export default function Rates() {
                 const text = (option?.children || option?.label)?.toString() || ""
                 return text.toLowerCase().includes(input.toLowerCase())
               }}
-              style={{ width: 200 }}
+              style={{ width: 200 * scale }}
             >
               {costCategories.map(cat => (
                 <Select.Option key={cat.id} value={cat.id}>
@@ -915,7 +918,7 @@ export default function Rates() {
                 const text = (option?.children || option?.label)?.toString() || ""
                 return text.toLowerCase().includes(input.toLowerCase())
               }}
-              style={{ width: 200 }}
+              style={{ width: 200 * scale }}
               disabled={!costCategoryFilter}
             >
               {filteredDetailCategories.map(detail => (
@@ -1025,9 +1028,9 @@ export default function Rates() {
         rowKey="id"
         loading={isLoading}
         sticky
-        scroll={{ 
+        scroll={{
           x: 'max-content',
-          y: 'calc(100vh - 350px)'
+          y: '100%'
         }}
           pagination={{
             current: 1,

--- a/src/shared/contexts/ScaleContext.tsx
+++ b/src/shared/contexts/ScaleContext.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+
+interface ScaleContextType {
+  scale: number
+  setScale: (value: number) => void
+}
+
+const ScaleContext = createContext<ScaleContextType | undefined>(undefined)
+
+export function ScaleProvider({ children }: { children: ReactNode }) {
+  const [scale, setScaleState] = useState<number>(() => {
+    const saved = localStorage.getItem('blueprintflow-scale')
+    return saved ? Number(saved) : 1
+  })
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--app-scale', String(scale))
+    localStorage.setItem('blueprintflow-scale', String(scale))
+  }, [scale])
+
+  const setScale = (value: number) => {
+    setScaleState(value)
+  }
+
+  return (
+    <ScaleContext.Provider value={{ scale, setScale }}>
+      {children}
+    </ScaleContext.Provider>
+  )
+}
+
+export function useScale() {
+  const context = useContext(ScaleContext)
+  if (!context) {
+    throw new Error('useScale must be used within ScaleProvider')
+  }
+  return context
+}
+


### PR DESCRIPTION
## Summary
- add CSS variable driven layout scaling
- scale header, menu and controls using current coefficient
- expand table area to fill remaining viewport height

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d55d800c832e905aa895e29f469a