### PR TITLE
fix: keep menu highlight within sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -439,7 +439,10 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
               border-radius: calc(4px * var(--app-scale)) !important;
               box-shadow: none !important;
               color: #a69ead !important;
-              margin: calc(2px * var(--app-scale)) calc(8px * var(--app-scale)) !important;
+              margin: calc(2px * var(--app-scale)) 0 !important;
+              padding: 0 calc(8px * var(--app-scale)) !important;
+              padding-left: calc(28px * var(--app-scale)) !important;
+              box-sizing: border-box !important;
             }
 
             .ant-menu-submenu .ant-menu-item-selected a {


### PR DESCRIPTION
## Summary
- adjust submenu item styling so active border stays within sidebar width during scale changes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b306ec7b48832e92c66536fd0201b6