### PR TITLE
feat: add materials reference for chessboard

### DIFF
--- a/src/entities/materials/api/materials-api.ts
+++ b/src/entities/materials/api/materials-api.ts
@@ -1,0 +1,47 @@
+import { supabase } from '@/lib/supabase'
+import type { Material } from '../model/types'
+
+export const materialsApi = {
+  async getAll(): Promise<Material[]> {
+    if (!supabase) throw new Error('Supabase is not configured')
+
+    const { data, error } = await supabase.from('materials').select('uuid, name').order('name')
+
+    if (error) {
+      console.error('Failed to fetch materials:', error)
+      throw error
+    }
+
+    return (data ?? []) as Material[]
+  },
+
+  async ensure(name: string): Promise<Material> {
+    if (!supabase) throw new Error('Supabase is not configured')
+
+    const { data, error } = await supabase
+      .from('materials')
+      .select('uuid, name')
+      .eq('name', name)
+      .maybeSingle()
+
+    if (error) {
+      console.error('Failed to fetch material:', error)
+      throw error
+    }
+
+    if (data) return data as Material
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('materials')
+      .insert({ name })
+      .select('uuid, name')
+      .single()
+
+    if (insertError) {
+      console.error('Failed to insert material:', insertError)
+      throw insertError
+    }
+
+    return inserted as Material
+  },
+}

--- a/src/entities/materials/index.ts
+++ b/src/entities/materials/index.ts
@@ -1,0 +1,2 @@
+export * from './api/materials-api'
+export * from './model/types'

--- a/src/entities/materials/model/types.ts
+++ b/src/entities/materials/model/types.ts
@@ -1,0 +1,4 @@
+export interface Material {
+  uuid: string
+  name: string
+}

--- a/src/pages/documents/Chessboard.tsx
+++ b/src/pages/documents/Chessboard.tsx
@@ -1,12 +1,48 @@
 import { useCallback, useMemo, useState, useEffect, type Key } from 'react'
-import { App, Badge, Button, Card, Checkbox, Drawer, Dropdown, Input, InputNumber, List, Modal, Popconfirm, Select, Space, Table, Typography, Upload } from 'antd'
+import {
+  App,
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  Drawer,
+  Dropdown,
+  AutoComplete,
+  Input,
+  InputNumber,
+  List,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Table,
+  Typography,
+  Upload,
+} from 'antd'
 import type { ColumnType, ColumnsType } from 'antd/es/table'
-import { ArrowDownOutlined, ArrowUpOutlined, BgColorsOutlined, CopyOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, InboxOutlined, PlusOutlined, SaveOutlined, SettingOutlined, FilterOutlined, CaretUpFilled, CaretDownFilled, UploadOutlined } from '@ant-design/icons'
+import {
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  BgColorsOutlined,
+  CopyOutlined,
+  DeleteOutlined,
+  DownloadOutlined,
+  EditOutlined,
+  InboxOutlined,
+  PlusOutlined,
+  SaveOutlined,
+  SettingOutlined,
+  FilterOutlined,
+  CaretUpFilled,
+  CaretDownFilled,
+  UploadOutlined,
+} from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
 import * as XLSX from 'xlsx'
 import { supabase } from '../../lib/supabase'
 import { documentationApi } from '@/entities/documentation'
 import { documentationTagsApi } from '@/entities/documentation-tags'
+import { materialsApi } from '@/entities/materials'
 import { useScale } from '@/shared/contexts/ScaleContext'
 
 type RowColor = '' | 'green' | 'yellow' | 'blue' | 'red'
@@ -64,6 +100,7 @@ type FloorQuantities = Record<number, FloorQuantity>
 interface RowData {
   key: string
   material: string
+  materialId: string
   quantityPd: string
   quantitySpec: string
   quantityRd: string
@@ -101,6 +138,7 @@ interface FloorModalInfo {
 
 interface ViewRow {
   key: string
+  materialId: string
   material: string
   quantityPd: string
   quantitySpec: string
@@ -126,24 +164,43 @@ interface TableRow extends RowData {
   isExisting?: boolean
 }
 
-interface ProjectOption { id: string; name: string }
-interface BlockOption { id: string; name: string }
-interface UnitOption { id: string; name: string }
-interface NomenclatureOption { id: string; name: string }
+interface ProjectOption {
+  id: string
+  name: string
+}
+interface BlockOption {
+  id: string
+  name: string
+}
+interface UnitOption {
+  id: string
+  name: string
+}
+interface NomenclatureOption {
+  id: string
+  name: string
+}
 interface DocumentationRecord {
   id: string
   project_code: string
   tag_id: number | null
   tag_name?: string | null
 }
-interface CostCategoryOption { id: number; number: number | null; name: string }
+interface CostCategoryOption {
+  id: number
+  number: number | null
+  name: string
+}
 interface CostTypeOption {
   id: number
   name: string
   cost_category_id: number
   location_id: number
 }
-interface LocationOption { id: number; name: string }
+interface LocationOption {
+  id: number
+  name: string
+}
 
 interface RateOption {
   id: string
@@ -160,6 +217,7 @@ type NomenclatureMapping = {
 interface DbRow {
   id: string
   material: string | null
+  materials?: { name: string | null } | null
   unit_id: string | null
   color: string | null
   floors?: string
@@ -176,10 +234,12 @@ interface DbRow {
     detail_cost_categories?: { name: string | null } | null
     location?: { name: string | null } | null
   } | null
-  chessboard_rates_mapping?: {
-    rate_id: string | null
-    rates?: { work_name: string | null } | null
-  }[] | null
+  chessboard_rates_mapping?:
+    | {
+        rate_id: string | null
+        rates?: { work_name: string | null } | null
+      }[]
+    | null
   chessboard_documentation_mapping?: {
     documentation_id: string | null
     documentations?: {
@@ -198,18 +258,17 @@ interface DbRow {
 
 const getNomenclatureMapping = (
   mapping: NomenclatureMapping | NomenclatureMapping[] | null | undefined,
-): NomenclatureMapping | null =>
-  Array.isArray(mapping) ? mapping[0] ?? null : mapping ?? null
+): NomenclatureMapping | null => (Array.isArray(mapping) ? (mapping[0] ?? null) : (mapping ?? null))
 
 // Функция для форматирования массива этажей в строку с диапазонами
 const formatFloorsString = (floors: number[]): string => {
   if (floors.length === 0) return ''
-  
+
   const sorted = [...floors].sort((a, b) => a - b)
   const ranges: string[] = []
   let start = sorted[0]
   let end = sorted[0]
-  
+
   for (let i = 1; i <= sorted.length; i++) {
     if (i < sorted.length && sorted[i] === end + 1) {
       end = sorted[i]
@@ -227,20 +286,20 @@ const formatFloorsString = (floors: number[]): string => {
       }
     }
   }
-  
+
   return ranges.join(',')
 }
 
 // Функция для парсинга строки этажей в массив чисел
 const parseFloorsString = (floorsStr: string): number[] => {
   if (!floorsStr || !floorsStr.trim()) return []
-  
+
   const floors = new Set<number>()
-  const parts = floorsStr.split(',').map(s => s.trim())
-  
+  const parts = floorsStr.split(',').map((s) => s.trim())
+
   for (const part of parts) {
     if (part.includes('-')) {
-      const [start, end] = part.split('-').map(s => parseInt(s.trim()))
+      const [start, end] = part.split('-').map((s) => parseInt(s.trim()))
       if (!isNaN(start) && !isNaN(end)) {
         for (let i = Math.min(start, end); i <= Math.max(start, end); i++) {
           floors.add(i)
@@ -253,13 +312,14 @@ const parseFloorsString = (floorsStr: string): number[] => {
       }
     }
   }
-  
+
   return Array.from(floors).sort((a, b) => a - b)
 }
 
 const emptyRow = (defaults: Partial<RowData>): RowData => ({
   key: Math.random().toString(36).slice(2),
   material: '',
+  materialId: '',
   quantityPd: '',
   quantitySpec: '',
   quantityRd: '',
@@ -293,11 +353,22 @@ export default function Chessboard() {
   const { message } = App.useApp()
   const { scale } = useScale()
 
-  
-  const [filters, setFilters] = useState<{ projectId?: string; blockId?: string; categoryId?: string; typeId?: string; tagId?: string; documentationId?: string }>({})
-  const [appliedFilters, setAppliedFilters] = useState<
-    { projectId: string; blockId?: string; categoryId?: string; typeId?: string; tagId?: string; documentationId?: string } | null
-  >(null)
+  const [filters, setFilters] = useState<{
+    projectId?: string
+    blockId?: string
+    categoryId?: string
+    typeId?: string
+    tagId?: string
+    documentationId?: string
+  }>({})
+  const [appliedFilters, setAppliedFilters] = useState<{
+    projectId: string
+    blockId?: string
+    categoryId?: string
+    typeId?: string
+    tagId?: string
+    documentationId?: string
+  } | null>(null)
   const [mode, setMode] = useState<'view' | 'add'>('view')
   const [rows, setRows] = useState<RowData[]>([])
   const [editingRows, setEditingRows] = useState<Record<string, RowData>>({})
@@ -322,7 +393,6 @@ export default function Chessboard() {
     typeId?: string
     locationId?: string
   }>({})
-
 
   const { data: projects } = useQuery<ProjectOption[]>({
     queryKey: ['projects'],
@@ -380,6 +450,16 @@ export default function Chessboard() {
     },
   })
 
+  const { data: materials, refetch: refetchMaterials } = useQuery({
+    queryKey: ['materials'],
+    queryFn: materialsApi.getAll,
+  })
+
+  const materialOptions = useMemo(
+    () => materials?.map((m) => ({ value: m.uuid, label: m.name })) ?? [],
+    [materials],
+  )
+
   const { data: nomenclatures } = useQuery<NomenclatureOption[]>({
     queryKey: ['nomenclature'],
     queryFn: async () => {
@@ -435,8 +515,8 @@ export default function Chessboard() {
   const loadSupplierOptions = useCallback(
     async (nomenclatureId: string | undefined, key: string, currentSupplier?: string) => {
       if (!nomenclatureId) {
-        setSupplierOptions(prev => ({ ...prev, [key]: [] }))
-        setSupplierDropdownWidths(prev => ({ ...prev, [key]: 250 }))
+        setSupplierOptions((prev) => ({ ...prev, [key]: [] }))
+        setSupplierDropdownWidths((prev) => ({ ...prev, [key]: 250 }))
         return
       }
       if (!supabase) return
@@ -446,17 +526,21 @@ export default function Chessboard() {
         .eq('nomenclature_id', nomenclatureId)
       if (error) {
         console.error('Не удалось загрузить поставщиков:', error.message)
-        setSupplierOptions(prev => ({ ...prev, [key]: [] }))
+        setSupplierOptions((prev) => ({ ...prev, [key]: [] }))
         return
       }
-      const options = (data as { supplier_names: { name: string | null } | { name: string | null }[] | null }[])
-        .map(d => (Array.isArray(d.supplier_names) ? d.supplier_names[0]?.name : d.supplier_names?.name))
+      const options = (
+        data as { supplier_names: { name: string | null } | { name: string | null }[] | null }[]
+      )
+        .map((d) =>
+          Array.isArray(d.supplier_names) ? d.supplier_names[0]?.name : d.supplier_names?.name,
+        )
         .filter((n): n is string => !!n)
-        .map(name => ({ value: name, label: name }))
-      if (currentSupplier && !options.some(o => o.value === currentSupplier)) {
+        .map((name) => ({ value: name, label: name }))
+      if (currentSupplier && !options.some((o) => o.value === currentSupplier)) {
         options.push({ value: currentSupplier, label: currentSupplier })
       }
-      setSupplierOptions(prev => ({ ...prev, [key]: options }))
+      setSupplierOptions((prev) => ({ ...prev, [key]: options }))
 
       if (typeof document !== 'undefined') {
         const canvas = document.createElement('canvas')
@@ -469,9 +553,9 @@ export default function Chessboard() {
             if (width > max) max = width
           }
           const width = Math.min(500, Math.ceil(max) + 64)
-          setSupplierDropdownWidths(prev => ({ ...prev, [key]: width }))
+          setSupplierDropdownWidths((prev) => ({ ...prev, [key]: width }))
         } else {
-          setSupplierDropdownWidths(prev => ({ ...prev, [key]: 200 }))
+          setSupplierDropdownWidths((prev) => ({ ...prev, [key]: 200 }))
         }
       }
     },
@@ -519,7 +603,8 @@ export default function Chessboard() {
     (costTypeId?: string, costCategoryId?: string) =>
       rates
         ?.filter((r) => {
-          const detailIds = r.rates_detail_cost_categories_mapping?.map((m) => m.detail_cost_category_id) ?? []
+          const detailIds =
+            r.rates_detail_cost_categories_mapping?.map((m) => m.detail_cost_category_id) ?? []
           if (costTypeId) {
             return detailIds.includes(Number(costTypeId))
           }
@@ -552,13 +637,13 @@ export default function Chessboard() {
     queryFn: documentationTagsApi.getAll,
   })
 
-  // Загрузка документации для выбранного проекта  
+  // Загрузка документации для выбранного проекта
   const { data: documentations } = useQuery<DocumentationRecord[]>({
     queryKey: ['documentations', appliedFilters?.projectId],
     queryFn: async () => {
-      console.log('📚 DOCUMENTATION QUERY - Executing:', { 
+      console.log('📚 DOCUMENTATION QUERY - Executing:', {
         projectId: appliedFilters?.projectId,
-        enabled: !!appliedFilters?.projectId 
+        enabled: !!appliedFilters?.projectId,
       })
       if (!appliedFilters?.projectId) {
         console.log('⚠️ DOCUMENTATION QUERY - No project ID, returning empty array')
@@ -566,18 +651,18 @@ export default function Chessboard() {
       }
       const fetchFilters = { project_id: appliedFilters.projectId }
       const result = await documentationApi.getDocumentation(fetchFilters)
-      
+
       console.log('✅ DOCUMENTATION QUERY - Loaded:', {
         projectId: appliedFilters.projectId,
         totalCount: result.length,
-        uniqueTagIds: [...new Set(result.map(doc => doc.tag_id))],
-        sampleData: result.slice(0, 5).map(doc => ({
+        uniqueTagIds: [...new Set(result.map((doc) => doc.tag_id))],
+        sampleData: result.slice(0, 5).map((doc) => ({
           id: doc.id,
           code: doc.project_code,
           tag_id: doc.tag_id,
           tag_name: doc.tag_name,
-          tag_number: doc.tag_number
-        }))
+          tag_number: doc.tag_number,
+        })),
       })
       return result
     },
@@ -592,7 +677,7 @@ export default function Chessboard() {
     documentationsCount: documentations?.length ?? 'undefined',
     mode,
     editingRowsCount: Object.keys(editingRows).length,
-    addRowsCount: rows.length
+    addRowsCount: rows.length,
   })
 
   const { data: tableData, refetch } = useQuery<DbRow[]>({
@@ -607,39 +692,48 @@ export default function Chessboard() {
       const query = supabase
         .from('chessboard')
         .select(
-          `id, material, unit_id, color, units(name),
+          `id, material, materials(name), unit_id, color, units(name),
           chessboard_nomenclature_mapping!left(nomenclature_id, supplier_name, nomenclature(name)),
           ${relation}(block_id, blocks(name), cost_category_id, cost_type_id, location_id, cost_categories(name), detail_cost_categories(name), location(name)),
           chessboard_rates_mapping(rate_id, rates(work_name)),
           chessboard_documentation_mapping(documentation_id, documentations(id, code, tag_id, stage, tag:documentation_tags(id, name, tag_number)))`,
         )
         .eq('project_id', appliedFilters.projectId)
-      if (appliedFilters.blockId)
-        query.eq('chessboard_mapping.block_id', appliedFilters.blockId)
+      if (appliedFilters.blockId) query.eq('chessboard_mapping.block_id', appliedFilters.blockId)
       if (appliedFilters.categoryId)
         query.eq('chessboard_mapping.cost_category_id', Number(appliedFilters.categoryId))
       if (appliedFilters.typeId)
         query.eq('chessboard_mapping.cost_type_id', Number(appliedFilters.typeId))
       // Фильтрация по документации
       if (appliedFilters.documentationId) {
-        query.eq('chessboard_documentation_mapping.documentation_id', appliedFilters.documentationId)
+        query.eq(
+          'chessboard_documentation_mapping.documentation_id',
+          appliedFilters.documentationId,
+        )
       } else if (appliedFilters.tagId) {
-        query.eq('chessboard_documentation_mapping.documentations.tag_id', Number(appliedFilters.tagId))
+        query.eq(
+          'chessboard_documentation_mapping.documentations.tag_id',
+          Number(appliedFilters.tagId),
+        )
       }
       const { data, error } = await query.order('created_at', { ascending: false })
       if (error) {
         message.error('Не удалось загрузить данные')
         throw error
       }
-      
+
       // Загружаем этажи для всех записей
-      const chessboardIds = ((data as unknown as DbRow[] | null | undefined) ?? []).map((item) => item.id)
+      const chessboardIds = ((data as unknown as DbRow[] | null | undefined) ?? []).map(
+        (item) => item.id,
+      )
       const floorsMap: Record<string, { floors: string; quantities: FloorQuantities }> = {}
 
       if (chessboardIds.length > 0) {
         const { data: floorsData } = await supabase
           .from('chessboard_floor_mapping')
-          .select('chessboard_id, floor_number, location_id, "quantityPd", "quantitySpec", "quantityRd"')
+          .select(
+            'chessboard_id, floor_number, location_id, "quantityPd", "quantitySpec", "quantityRd"',
+          )
           .in('chessboard_id', chessboardIds)
           .order('floor_number', { ascending: true })
 
@@ -655,42 +749,43 @@ export default function Chessboard() {
               quantitySpec: number | null
               quantityRd: number | null
             }) => {
-            if (!grouped[item.chessboard_id]) {
-              grouped[item.chessboard_id] = { floors: [], quantities: {} }
-            }
-            if (item.floor_number !== null && item.floor_number !== undefined) {
-              grouped[item.chessboard_id].floors.push(item.floor_number)
-              grouped[item.chessboard_id].quantities[item.floor_number] = {
-                quantityPd:
-                  item.quantityPd !== null && item.quantityPd !== undefined
-                    ? String(item.quantityPd)
-                    : '',
-                quantitySpec:
-                  item.quantitySpec !== null && item.quantitySpec !== undefined
-                    ? String(item.quantitySpec)
-                    : '',
-                quantityRd:
-                  item.quantityRd !== null && item.quantityRd !== undefined
-                    ? String(item.quantityRd)
-                    : '',
+              if (!grouped[item.chessboard_id]) {
+                grouped[item.chessboard_id] = { floors: [], quantities: {} }
               }
-            } else {
-              grouped[item.chessboard_id].quantities[0] = {
-                quantityPd:
-                  item.quantityPd !== null && item.quantityPd !== undefined
-                    ? String(item.quantityPd)
-                    : '',
-                quantitySpec:
-                  item.quantitySpec !== null && item.quantitySpec !== undefined
-                    ? String(item.quantitySpec)
-                    : '',
-                quantityRd:
-                  item.quantityRd !== null && item.quantityRd !== undefined
-                    ? String(item.quantityRd)
-                    : '',
+              if (item.floor_number !== null && item.floor_number !== undefined) {
+                grouped[item.chessboard_id].floors.push(item.floor_number)
+                grouped[item.chessboard_id].quantities[item.floor_number] = {
+                  quantityPd:
+                    item.quantityPd !== null && item.quantityPd !== undefined
+                      ? String(item.quantityPd)
+                      : '',
+                  quantitySpec:
+                    item.quantitySpec !== null && item.quantitySpec !== undefined
+                      ? String(item.quantitySpec)
+                      : '',
+                  quantityRd:
+                    item.quantityRd !== null && item.quantityRd !== undefined
+                      ? String(item.quantityRd)
+                      : '',
+                }
+              } else {
+                grouped[item.chessboard_id].quantities[0] = {
+                  quantityPd:
+                    item.quantityPd !== null && item.quantityPd !== undefined
+                      ? String(item.quantityPd)
+                      : '',
+                  quantitySpec:
+                    item.quantitySpec !== null && item.quantitySpec !== undefined
+                      ? String(item.quantitySpec)
+                      : '',
+                  quantityRd:
+                    item.quantityRd !== null && item.quantityRd !== undefined
+                      ? String(item.quantityRd)
+                      : '',
+                }
               }
-            }
-          })
+            },
+          )
 
           // Преобразуем массивы этажей в строки с диапазонами
           for (const [id, { floors, quantities }] of Object.entries(grouped)) {
@@ -699,8 +794,8 @@ export default function Chessboard() {
               quantities,
             }
           }
+        }
       }
-    }
 
       // Добавляем этажи и количества к результатам
       const result = (data as unknown as DbRow[]) ?? []
@@ -740,12 +835,15 @@ export default function Chessboard() {
           : null
         return {
           key: item.id,
-          material: item.material ?? '',
+          materialId: item.material ?? '',
+          material: item.materials?.name ?? '',
           quantityPd: sumPd !== null ? String(sumPd) : '',
           quantitySpec: sumSpec !== null ? String(sumSpec) : '',
           quantityRd: sumRd !== null ? String(sumRd) : '',
-          nomenclatureId: getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature_id ?? '',
-          nomenclature: getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature?.name ?? '',
+          nomenclatureId:
+            getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature_id ?? '',
+          nomenclature:
+            getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.nomenclature?.name ?? '',
           supplier:
             getNomenclatureMapping(item.chessboard_nomenclature_mapping)?.supplier_name ?? '',
           unit: item.units?.name ?? '',
@@ -771,6 +869,7 @@ export default function Chessboard() {
       ...viewRows.map((v) => ({
         key: v.key,
         material: v.material,
+        materialId: v.materialId,
         quantityPd: v.quantityPd,
         quantitySpec: v.quantitySpec,
         quantityRd: v.quantityRd,
@@ -812,12 +911,10 @@ export default function Chessboard() {
     (index: number) => {
       if (!appliedFilters) return
       const defaultLocationId = appliedFilters.typeId
-        ? String(
-            costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '',
-          )
+        ? String(costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '')
         : ''
       const blockName = appliedFilters.blockId
-        ? blocks?.find((b) => b.id === appliedFilters.blockId)?.name ?? ''
+        ? (blocks?.find((b) => b.id === appliedFilters.blockId)?.name ?? '')
         : ''
       setRows((prev) => {
         const newRow = emptyRow({
@@ -845,14 +942,14 @@ export default function Chessboard() {
       return next
     })
   }, [])
-  
+
   const deleteRow = useCallback((key: string) => {
     setRows((prev) => prev.filter((r) => r.key !== key))
   }, [])
-  
+
   const handleDeleteSelected = useCallback(async () => {
     if (!supabase || selectedRows.size === 0) return
-    
+
     const idsToDelete = Array.from(selectedRows)
 
     try {
@@ -862,7 +959,7 @@ export default function Chessboard() {
         await supabase!.from('chessboard_mapping').delete().eq('chessboard_id', id)
         await supabase!.from('chessboard').delete().eq('id', id)
       })
-      
+
       await Promise.all(deletePromises)
       message.success(`Удалено строк: ${idsToDelete.length}`)
       setSelectedRows(new Set())
@@ -872,9 +969,9 @@ export default function Chessboard() {
       message.error(`Не удалось удалить строки: ${(error as Error).message}`)
     }
   }, [selectedRows, message, refetch])
-  
+
   const toggleRowSelection = useCallback((key: string) => {
-    setSelectedRows(prev => {
+    setSelectedRows((prev) => {
       const newSet = new Set(prev)
       if (newSet.has(key)) {
         newSet.delete(key)
@@ -886,8 +983,8 @@ export default function Chessboard() {
   }, [])
 
   const handleRowChange = useCallback((key: string, field: keyof RowData, value: string) => {
-    setRows(prev =>
-      prev.map(r =>
+    setRows((prev) =>
+      prev.map((r) =>
         r.key === key
           ? {
               ...r,
@@ -901,18 +998,30 @@ export default function Chessboard() {
     )
   }, [])
 
-  const handleEditChange = useCallback(
-    (key: string, field: keyof RowData, value: string) => {
-      setEditingRows(prev => {
-        const updated = { ...prev[key], [field]: value }
-        if (field === 'quantityPd' || field === 'quantitySpec' || field === 'quantityRd') {
-          delete updated.floorQuantities
-        }
-        return { ...prev, [key]: updated }
-      })
+  const handleMaterialBlur = useCallback(
+    async (key: string, name: string) => {
+      if (!name.trim()) return
+      try {
+        const material = await materialsApi.ensure(name.trim())
+        handleRowChange(key, 'materialId', material.uuid)
+        handleRowChange(key, 'material', material.name)
+        await refetchMaterials()
+      } catch (e) {
+        message.error(`Не удалось сохранить материал: ${(e as Error).message}`)
+      }
     },
-    [],
+    [handleRowChange, refetchMaterials, message],
   )
+
+  const handleEditChange = useCallback((key: string, field: keyof RowData, value: string) => {
+    setEditingRows((prev) => {
+      const updated = { ...prev[key], [field]: value }
+      if (field === 'quantityPd' || field === 'quantitySpec' || field === 'quantityRd') {
+        delete updated.floorQuantities
+      }
+      return { ...prev, [key]: updated }
+    })
+  }, [])
 
   const [floorModalOpen, setFloorModalOpen] = useState(false)
   const [floorModalRowKey, setFloorModalRowKey] = useState<string | null>(null)
@@ -923,12 +1032,14 @@ export default function Chessboard() {
   const openFloorModal = useCallback(
     (key: string, isEdit: boolean) => {
       const row = isEdit
-        ? editingRows[key] ?? rows.find(r => r.key === key) ?? tableData?.find(r => r.id === key)
-        : rows.find(r => r.key === key) ?? tableData?.find(r => r.id === key)
+        ? (editingRows[key] ??
+          rows.find((r) => r.key === key) ??
+          tableData?.find((r) => r.id === key))
+        : (rows.find((r) => r.key === key) ?? tableData?.find((r) => r.id === key))
       if (!row) return
       const floors = parseFloorsString(row.floors || '')
       const quantities = row.floorQuantities || {}
-      const data = floors.map(f => ({
+      const data = floors.map((f) => ({
         floor: f,
         quantityPd: quantities[f]?.quantityPd || '',
         quantitySpec: quantities[f]?.quantitySpec || '',
@@ -936,16 +1047,16 @@ export default function Chessboard() {
       }))
       const unitName =
         'unitId' in row
-          ? units?.find(u => String(u.id) === row.unitId)?.name ?? ''
-          : row.units?.name ?? ''
+          ? (units?.find((u) => String(u.id) === row.unitId)?.name ?? '')
+          : (row.units?.name ?? '')
       const workName =
         'costTypeId' in row
-          ? costTypes?.find(t => String(t.id) === row.costTypeId)?.name ?? ''
-          : row.chessboard_mapping?.detail_cost_categories?.name ?? ''
+          ? (costTypes?.find((t) => String(t.id) === row.costTypeId)?.name ?? '')
+          : (row.chessboard_mapping?.detail_cost_categories?.name ?? '')
       const projectCode =
         'projectCode' in row
           ? row.projectCode
-          : (row as DbRow).chessboard_documentation_mapping?.documentations?.code ?? ''
+          : ((row as DbRow).chessboard_documentation_mapping?.documentations?.code ?? '')
       setFloorModalInfo({
         projectCode,
         workName,
@@ -962,9 +1073,11 @@ export default function Chessboard() {
 
   const handleFloorModalChange = useCallback(
     (index: number, field: keyof FloorQuantity | 'floor', value: string | number) => {
-      setFloorModalData(prev =>
+      setFloorModalData((prev) =>
         prev.map((item, i) =>
-          i === index ? { ...item, [field]: field === 'floor' ? Number(value) : String(value) } : item,
+          i === index
+            ? { ...item, [field]: field === 'floor' ? Number(value) : String(value) }
+            : item,
         ),
       )
     },
@@ -972,11 +1085,14 @@ export default function Chessboard() {
   )
 
   const addFloorModalRow = useCallback(() => {
-    setFloorModalData(prev => [...prev, { floor: 0, quantityPd: '', quantitySpec: '', quantityRd: '' }])
+    setFloorModalData((prev) => [
+      ...prev,
+      { floor: 0, quantityPd: '', quantitySpec: '', quantityRd: '' },
+    ])
   }, [])
 
   const removeFloorModalRow = useCallback((index: number) => {
-    setFloorModalData(prev => prev.filter((_, i) => i !== index))
+    setFloorModalData((prev) => prev.filter((_, i) => i !== index))
   }, [])
 
   const floorModalColumns = useMemo<ColumnsType<FloorModalRow>>(
@@ -988,7 +1104,7 @@ export default function Chessboard() {
           floorModalIsEdit ? (
             <InputNumber
               value={record.floor}
-              onChange={value => handleFloorModalChange(index, 'floor', value ?? 0)}
+              onChange={(value) => handleFloorModalChange(index, 'floor', value ?? 0)}
             />
           ) : (
             record.floor
@@ -1002,7 +1118,7 @@ export default function Chessboard() {
             <Input
               style={{ width: '10ch' }}
               value={record.quantityPd}
-              onChange={e => handleFloorModalChange(index, 'quantityPd', e.target.value)}
+              onChange={(e) => handleFloorModalChange(index, 'quantityPd', e.target.value)}
             />
           ) : (
             record.quantityPd
@@ -1016,7 +1132,7 @@ export default function Chessboard() {
             <Input
               style={{ width: '10ch' }}
               value={record.quantitySpec}
-              onChange={e => handleFloorModalChange(index, 'quantitySpec', e.target.value)}
+              onChange={(e) => handleFloorModalChange(index, 'quantitySpec', e.target.value)}
             />
           ) : (
             record.quantitySpec
@@ -1030,7 +1146,7 @@ export default function Chessboard() {
             <Input
               style={{ width: '10ch' }}
               value={record.quantityRd}
-              onChange={e => handleFloorModalChange(index, 'quantityRd', e.target.value)}
+              onChange={(e) => handleFloorModalChange(index, 'quantityRd', e.target.value)}
             />
           ) : (
             record.quantityRd
@@ -1059,7 +1175,7 @@ export default function Chessboard() {
     if (!floorModalRowKey) return
     const map: FloorQuantities = {}
     const floorNums: number[] = []
-    floorModalData.forEach(d => {
+    floorModalData.forEach((d) => {
       const num = Number(d.floor)
       if (!isNaN(num)) {
         floorNums.push(num)
@@ -1076,7 +1192,7 @@ export default function Chessboard() {
     const totalSpec = floorModalData.reduce((s, d) => s + (parseFloat(d.quantitySpec) || 0), 0)
     const totalRd = floorModalData.reduce((s, d) => s + (parseFloat(d.quantityRd) || 0), 0)
     if (floorModalIsEdit && editingRows[floorModalRowKey]) {
-      setEditingRows(prev => ({
+      setEditingRows((prev) => ({
         ...prev,
         [floorModalRowKey]: {
           ...prev[floorModalRowKey],
@@ -1088,8 +1204,8 @@ export default function Chessboard() {
         },
       }))
     } else {
-      setRows(prev =>
-        prev.map(r =>
+      setRows((prev) =>
+        prev.map((r) =>
           r.key === floorModalRowKey
             ? {
                 ...r,
@@ -1111,12 +1227,10 @@ export default function Chessboard() {
   const startAdd = useCallback(() => {
     if (!appliedFilters) return
     const defaultLocationId = appliedFilters.typeId
-      ? String(
-          costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '',
-        )
+      ? String(costTypes?.find((t) => String(t.id) === appliedFilters.typeId)?.location_id ?? '')
       : ''
     const blockName = appliedFilters.blockId
-      ? blocks?.find((b) => b.id === appliedFilters.blockId)?.name ?? ''
+      ? (blocks?.find((b) => b.id === appliedFilters.blockId)?.name ?? '')
       : ''
     setRows([
       emptyRow({
@@ -1143,34 +1257,32 @@ export default function Chessboard() {
           ...prev,
           [id]: {
             key: id,
-            material: dbRow.material ?? '',
-            quantityPd:
-              dbRow.floorQuantities
-                ? String(
-                    Object.values(dbRow.floorQuantities).reduce(
-                      (s, q) => s + (parseFloat(q.quantityPd) || 0),
-                      0,
-                    ),
-                  )
-                : '',
-            quantitySpec:
-              dbRow.floorQuantities
-                ? String(
-                    Object.values(dbRow.floorQuantities).reduce(
-                      (s, q) => s + (parseFloat(q.quantitySpec) || 0),
-                      0,
-                    ),
-                  )
-                : '',
-            quantityRd:
-              dbRow.floorQuantities
-                ? String(
-                    Object.values(dbRow.floorQuantities).reduce(
-                      (s, q) => s + (parseFloat(q.quantityRd) || 0),
-                      0,
-                    ),
-                  )
-                : '',
+            materialId: dbRow.material ?? '',
+            material: dbRow.materials?.name ?? '',
+            quantityPd: dbRow.floorQuantities
+              ? String(
+                  Object.values(dbRow.floorQuantities).reduce(
+                    (s, q) => s + (parseFloat(q.quantityPd) || 0),
+                    0,
+                  ),
+                )
+              : '',
+            quantitySpec: dbRow.floorQuantities
+              ? String(
+                  Object.values(dbRow.floorQuantities).reduce(
+                    (s, q) => s + (parseFloat(q.quantitySpec) || 0),
+                    0,
+                  ),
+                )
+              : '',
+            quantityRd: dbRow.floorQuantities
+              ? String(
+                  Object.values(dbRow.floorQuantities).reduce(
+                    (s, q) => s + (parseFloat(q.quantityRd) || 0),
+                    0,
+                  ),
+                )
+              : '',
             nomenclatureId,
             supplier: supplierName,
             unitId: dbRow.unit_id ?? '',
@@ -1209,18 +1321,23 @@ export default function Chessboard() {
 
   const handleUpdate = useCallback(async () => {
     if (!supabase || Object.keys(editingRows).length === 0) return
-    
+
     // Параллельное выполнение всех обновлений
     const updatePromises = Object.values(editingRows).map(async (r) => {
+      let materialId = r.materialId
+      if (!materialId && r.material) {
+        const material = await materialsApi.ensure(r.material)
+        materialId = material.uuid
+      }
       const updateChessboard = supabase!
         .from('chessboard')
         .update({
-          material: r.material,
+          material: materialId,
           unit_id: r.unitId || null,
           color: r.color || null,
         })
         .eq('id', r.key)
-      
+
       const updateMapping = supabase!.from('chessboard_mapping').upsert(
         {
           chessboard_id: r.key,
@@ -1231,37 +1348,35 @@ export default function Chessboard() {
         },
         { onConflict: 'chessboard_id' },
       )
-      
+
       // Обновляем этажи
       const updateFloors = async () => {
         // Сначала удаляем старые связи
-        await supabase!.from('chessboard_floor_mapping')
-          .delete()
-          .eq('chessboard_id', r.key)
+        await supabase!.from('chessboard_floor_mapping').delete().eq('chessboard_id', r.key)
 
         // Парсим строку этажей и добавляем новые
         const floors = parseFloorsString(r.floors)
         const floorQuantities = r.floorQuantities
         if (floors.length > 0) {
           const totalFloors = floors.length
-          const floorMappings = floors.map(floor => ({
+          const floorMappings = floors.map((floor) => ({
             chessboard_id: r.key,
             floor_number: floor,
             quantityPd: floorQuantities?.[floor]?.quantityPd
               ? Number(floorQuantities[floor].quantityPd)
               : r.quantityPd
-              ? Number(r.quantityPd) / totalFloors
-              : null,
+                ? Number(r.quantityPd) / totalFloors
+                : null,
             quantitySpec: floorQuantities?.[floor]?.quantitySpec
               ? Number(floorQuantities[floor].quantitySpec)
               : r.quantitySpec
-              ? Number(r.quantitySpec) / totalFloors
-              : null,
+                ? Number(r.quantitySpec) / totalFloors
+                : null,
             quantityRd: floorQuantities?.[floor]?.quantityRd
               ? Number(floorQuantities[floor].quantityRd)
               : r.quantityRd
-              ? Number(r.quantityRd) / totalFloors
-              : null,
+                ? Number(r.quantityRd) / totalFloors
+                : null,
           }))
           await supabase!.from('chessboard_floor_mapping').insert(floorMappings)
         } else {
@@ -1272,28 +1387,25 @@ export default function Chessboard() {
             quantityPd: qty?.quantityPd
               ? Number(qty.quantityPd)
               : r.quantityPd
-              ? Number(r.quantityPd)
-              : null,
+                ? Number(r.quantityPd)
+                : null,
             quantitySpec: qty?.quantitySpec
               ? Number(qty.quantitySpec)
               : r.quantitySpec
-              ? Number(r.quantitySpec)
-              : null,
+                ? Number(r.quantitySpec)
+                : null,
             quantityRd: qty?.quantityRd
               ? Number(qty.quantityRd)
               : r.quantityRd
-              ? Number(r.quantityRd)
-              : null,
+                ? Number(r.quantityRd)
+                : null,
           })
         }
       }
 
       // Обновляем связь с номенклатурой
       const updateNomenclatureMapping = async () => {
-        await supabase!
-          .from('chessboard_nomenclature_mapping')
-          .delete()
-          .eq('chessboard_id', r.key)
+        await supabase!.from('chessboard_nomenclature_mapping').delete().eq('chessboard_id', r.key)
         if (r.nomenclatureId) {
           await supabase!.from('chessboard_nomenclature_mapping').insert({
             chessboard_id: r.key,
@@ -1337,10 +1449,7 @@ export default function Chessboard() {
       // Обновляем связь с расценками
       const updateRateMapping = async () => {
         // Сначала удаляем текущую связь, чтобы исключить конфликт ключей
-        await supabase!
-          .from('chessboard_rates_mapping')
-          .delete()
-          .eq('chessboard_id', r.key)
+        await supabase!.from('chessboard_rates_mapping').delete().eq('chessboard_id', r.key)
 
         // Если расценка выбрана, создаём новую запись
         if (r.rateId) {
@@ -1360,16 +1469,17 @@ export default function Chessboard() {
         updateRateMapping(),
       ])
     })
-    
+
     try {
       await Promise.all(updatePromises)
+      await refetchMaterials()
       message.success('Изменения сохранены')
       setEditingRows({})
       await refetch()
     } catch (error: unknown) {
       message.error(`Не удалось сохранить изменения: ${(error as Error).message}`)
     }
-  }, [editingRows, message, refetch, appliedFilters])
+  }, [editingRows, message, refetch, appliedFilters, refetchMaterials])
 
   const handleCancelEdit = useCallback(() => {
     setEditingRows({})
@@ -1439,11 +1549,18 @@ export default function Chessboard() {
       const materialIdx = header.findIndex((h) => h.includes('материал'))
       const quantityIdx = header.findIndex((h) => h.includes('кол'))
       const unitIdx = header.findIndex((h) => h.includes('ед'))
+      const materialMap: Record<string, string> = {}
       for (let i = 1; i < rows.length; i++) {
         const row = rows[i]
         const materialCol = materialIdx >= 0 ? materialIdx : 0
         const material = row[materialCol] != null ? String(row[materialCol]).trim() : ''
         if (!material) continue
+
+        if (!materialMap[material]) {
+          const m = await materialsApi.ensure(material)
+          materialMap[material] = m.uuid
+        }
+        const materialId = materialMap[material]
 
         const quantityCell = quantityIdx >= 0 ? row[quantityIdx] : undefined
         const unitName = unitIdx >= 0 ? String(row[unitIdx] ?? '').trim() : ''
@@ -1459,7 +1576,7 @@ export default function Chessboard() {
 
         payload.push({
           project_id: importState.projectId,
-          material,
+          material: materialId,
           unit_id: unitId,
         })
         quantities.push(quantity)
@@ -1480,9 +1597,7 @@ export default function Chessboard() {
         cost_type_id: importState.typeId ? Number(importState.typeId) : null,
         location_id: importState.locationId ? Number(importState.locationId) : null,
       }))
-      const { error: mapError } = await supabase!
-        .from('chessboard_mapping')
-        .insert(mappings)
+      const { error: mapError } = await supabase!.from('chessboard_mapping').insert(mappings)
       if (mapError) throw mapError
       const floorMappings = inserted.map((d, idx) => ({
         chessboard_id: d.id,
@@ -1494,6 +1609,7 @@ export default function Chessboard() {
       if (floorMappings.length > 0) {
         await supabase!.from('chessboard_floor_mapping').insert(floorMappings)
       }
+      await refetchMaterials()
       message.success('Импорт завершен')
       setImportOpen(false)
       setImportFile(null)
@@ -1502,16 +1618,25 @@ export default function Chessboard() {
     } catch (e) {
       message.error(`Не удалось импортировать: ${(e as Error).message}`)
     }
-  }, [importFile, importState, message, refetch, units])
+  }, [importFile, importState, message, refetch, units, refetchMaterials])
 
   const handleSave = async () => {
     if (!supabase || !appliedFilters) return
-    const payload = rows.map((r) => ({
-      project_id: appliedFilters.projectId,
-      material: r.material,
-      unit_id: r.unitId || null,
-      color: r.color || null,
-    }))
+    const payload = await Promise.all(
+      rows.map(async (r) => {
+        let materialId = r.materialId
+        if (!materialId && r.material) {
+          const m = await materialsApi.ensure(r.material)
+          materialId = m.uuid
+        }
+        return {
+          project_id: appliedFilters.projectId,
+          material: materialId,
+          unit_id: r.unitId || null,
+          color: r.color || null,
+        }
+      }),
+    )
     const { data, error } = await supabase.from('chessboard').insert(payload).select('id')
     if (error || !data) {
       message.error(`Не удалось сохранить данные: ${error?.message}`)
@@ -1558,39 +1683,43 @@ export default function Chessboard() {
       )
       .filter((m): m is { chessboard_id: string; rate_id: string } => !!m)
     if (rateMappings.length > 0) {
-      const { error: rateError } = await supabase.from('chessboard_rates_mapping').insert(rateMappings)
+      const { error: rateError } = await supabase
+        .from('chessboard_rates_mapping')
+        .insert(rateMappings)
       if (rateError) {
         message.error(`Не удалось сохранить связи с расценками: ${rateError.message}`)
         return
       }
     }
-    
+
     // Сохраняем этажи или локации
     for (let idx = 0; idx < data.length; idx++) {
       const floors = parseFloorsString(rows[idx].floors)
       const floorQuantities = rows[idx].floorQuantities
       if (floors.length > 0) {
         const totalFloors = floors.length
-        const floorMappings = floors.map(floor => ({
+        const floorMappings = floors.map((floor) => ({
           chessboard_id: data[idx].id,
           floor_number: floor,
           quantityPd: floorQuantities?.[floor]?.quantityPd
             ? Number(floorQuantities[floor].quantityPd)
             : rows[idx].quantityPd
-            ? Number(rows[idx].quantityPd) / totalFloors
-            : null,
+              ? Number(rows[idx].quantityPd) / totalFloors
+              : null,
           quantitySpec: floorQuantities?.[floor]?.quantitySpec
             ? Number(floorQuantities[floor].quantitySpec)
             : rows[idx].quantitySpec
-            ? Number(rows[idx].quantitySpec) / totalFloors
-            : null,
+              ? Number(rows[idx].quantitySpec) / totalFloors
+              : null,
           quantityRd: floorQuantities?.[floor]?.quantityRd
             ? Number(floorQuantities[floor].quantityRd)
             : rows[idx].quantityRd
-            ? Number(rows[idx].quantityRd) / totalFloors
-            : null,
+              ? Number(rows[idx].quantityRd) / totalFloors
+              : null,
         }))
-        const { error: floorError } = await supabase.from('chessboard_floor_mapping').insert(floorMappings)
+        const { error: floorError } = await supabase
+          .from('chessboard_floor_mapping')
+          .insert(floorMappings)
         if (floorError) {
           console.error(`Не удалось сохранить этажи: ${floorError.message}`)
         }
@@ -1602,25 +1731,25 @@ export default function Chessboard() {
           quantityPd: qty?.quantityPd
             ? Number(qty.quantityPd)
             : rows[idx].quantityPd
-            ? Number(rows[idx].quantityPd)
-            : null,
+              ? Number(rows[idx].quantityPd)
+              : null,
           quantitySpec: qty?.quantitySpec
             ? Number(qty.quantitySpec)
             : rows[idx].quantitySpec
-            ? Number(rows[idx].quantitySpec)
-            : null,
+              ? Number(rows[idx].quantitySpec)
+              : null,
           quantityRd: qty?.quantityRd
             ? Number(qty.quantityRd)
             : rows[idx].quantityRd
-            ? Number(rows[idx].quantityRd)
-            : null,
+              ? Number(rows[idx].quantityRd)
+              : null,
         })
         if (floorError) {
           console.error(`Не удалось сохранить локацию: ${floorError.message}`)
         }
       }
     }
-    
+
     // Сохраняем связь с документацией
     for (let idx = 0; idx < data.length; idx++) {
       let docId = rows[idx].documentationId
@@ -1644,7 +1773,7 @@ export default function Chessboard() {
         }
       }
     }
-    
+    await refetchMaterials()
     message.success('Данные успешно сохранены')
     setMode('view')
     setRows([])
@@ -1655,7 +1784,6 @@ export default function Chessboard() {
     setRows([])
     setMode('view')
   }, [])
-
 
   const addColumns: ColumnsType<TableRow> = useMemo(() => {
     const map: Record<string, keyof ViewRow> = {
@@ -1724,305 +1852,336 @@ export default function Chessboard() {
         return aIndex - bIndex
       })
       .map((col) => {
-      const values = Array.from(
-        new Set(viewRows.map((row) => row[map[col.dataIndex] as keyof ViewRow]).filter((v) => v)),
-      )
-      const filters = values.map((v) => ({ text: String(v), value: String(v) }))
+        const values = Array.from(
+          new Set(viewRows.map((row) => row[map[col.dataIndex] as keyof ViewRow]).filter((v) => v)),
+        )
+        const filters = values.map((v) => ({ text: String(v), value: String(v) }))
 
-      const sorter = (a: TableRow, b: TableRow) => {
-        const aVal = a[col.dataIndex]
-        const bVal = b[col.dataIndex]
-        const aNum = Number(aVal)
-        const bNum = Number(bVal)
-        if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
-        return String(aVal ?? '').localeCompare(String(bVal ?? ''))
-      }
+        const sorter = (a: TableRow, b: TableRow) => {
+          const aVal = a[col.dataIndex]
+          const bVal = b[col.dataIndex]
+          const aNum = Number(aVal)
+          const bNum = Number(bVal)
+          if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
+          return String(aVal ?? '').localeCompare(String(bVal ?? ''))
+        }
 
-      const onFilter = (value: boolean | Key, record: TableRow) =>
-        String(record[col.dataIndex] ?? '') === String(value)
+        const onFilter = (value: boolean | Key, record: TableRow) =>
+          String(record[col.dataIndex] ?? '') === String(value)
 
-      const render: ColumnType<TableRow>['render'] = (_, record) => {
-        if (record.isExisting) return record[col.dataIndex] as string
-        switch (col.dataIndex) {
-          case 'tagName':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={record.tagId}
-                onChange={(value) => {
-                  handleRowChange(record.key, 'tagId', value)
-                  const tag = documentationTags?.find((t) => String(t.id) === value)
-                  handleRowChange(record.key, 'tagName', tag ? `${tag.tag_number || ''} ${tag.name}`.trim() : '')
-                  // Сбрасываем выбранный документ при смене тэга
-                  handleRowChange(record.key, 'documentationId', '')
-                  handleRowChange(record.key, 'projectCode', '')
-                }}
-                options={
-                  documentationTags?.map((tag) => ({
-                    value: String(tag.id),
-                    label: `${tag.tag_number || ''} ${tag.name}`.trim()
-                  })) ?? []
-                }
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-            )
-          case 'projectCode':
-            return (
-              <Select
-                style={{ width: 150 }}
-                value={record.documentationId}
-                onDropdownVisibleChange={(open) => {
-                  if (open) {
-                    const filteredDocs = documentations?.filter((doc: DocumentationRecord) => !record.tagId || String(doc.tag_id) === record.tagId) ?? []
-                    console.log('🔽 ADD MODE - Project Code dropdown opened:', {
-                      recordKey: record.key,
-                      tagId: record.tagId,
-                      totalDocs: documentations?.length ?? 0,
-                      filteredDocs: filteredDocs.length,
-                      availableOptions: filteredDocs.length
-                    })
-                  }
-                }}
-                onChange={(value) => {
-                  console.log('✏️ ADD MODE - Project Code selected:', { value, recordKey: record.key })
-                  handleRowChange(record.key, 'documentationId', value)
-                  const doc = documentations?.find((d: DocumentationRecord) => d.id === value)
-                  handleRowChange(record.key, 'projectCode', doc?.project_code ?? '')
-                }}
-                options={
-                  documentations
-                    ?.filter((doc: DocumentationRecord) => {
-                      const matches = !record.tagId || String(doc.tag_id) === record.tagId
-                      console.log('🔍 ADD MODE - Filtering documentation:', {
-                        docId: doc.id,
-                        docCode: doc.project_code,
-                        docTagId: doc.tag_id,
-                        recordTagId: record.tagId,
-                        matches,
-                        docTagName: doc.tag_name
-                      })
-                      return matches
-                    })
-                    .map((doc: DocumentationRecord) => ({
-                      value: doc.id,
-                      label: doc.project_code
+        const render: ColumnType<TableRow>['render'] = (_, record) => {
+          if (record.isExisting) return record[col.dataIndex] as string
+          switch (col.dataIndex) {
+            case 'tagName':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={record.tagId}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'tagId', value)
+                    const tag = documentationTags?.find((t) => String(t.id) === value)
+                    handleRowChange(
+                      record.key,
+                      'tagName',
+                      tag ? `${tag.tag_number || ''} ${tag.name}`.trim() : '',
+                    )
+                    // Сбрасываем выбранный документ при смене тэга
+                    handleRowChange(record.key, 'documentationId', '')
+                    handleRowChange(record.key, 'projectCode', '')
+                  }}
+                  options={
+                    documentationTags?.map((tag) => ({
+                      value: String(tag.id),
+                      label: `${tag.tag_number || ''} ${tag.name}`.trim(),
                     })) ?? []
-                }
-                disabled={!record.tagId}
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-            )
-          case 'material':
-            return (
-              <Input
-                style={{ width: 300 }}
-                value={record.material}
-                onChange={(e) => handleRowChange(record.key, 'material', e.target.value)}
-              />
-            )
-          case 'quantityPd':
-            return (
-              <Space>
-                {parseFloorsString(record.floors).length > 1 && (
-                  <Button
-                    type="text"
-                    icon={<PlusOutlined />}
-                    onClick={() => openFloorModal(record.key, true)}
+                  }
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'projectCode':
+              return (
+                <Select
+                  style={{ width: 150 }}
+                  value={record.documentationId}
+                  onDropdownVisibleChange={(open) => {
+                    if (open) {
+                      const filteredDocs =
+                        documentations?.filter(
+                          (doc: DocumentationRecord) =>
+                            !record.tagId || String(doc.tag_id) === record.tagId,
+                        ) ?? []
+                      console.log('🔽 ADD MODE - Project Code dropdown opened:', {
+                        recordKey: record.key,
+                        tagId: record.tagId,
+                        totalDocs: documentations?.length ?? 0,
+                        filteredDocs: filteredDocs.length,
+                        availableOptions: filteredDocs.length,
+                      })
+                    }
+                  }}
+                  onChange={(value) => {
+                    console.log('✏️ ADD MODE - Project Code selected:', {
+                      value,
+                      recordKey: record.key,
+                    })
+                    handleRowChange(record.key, 'documentationId', value)
+                    const doc = documentations?.find((d: DocumentationRecord) => d.id === value)
+                    handleRowChange(record.key, 'projectCode', doc?.project_code ?? '')
+                  }}
+                  options={
+                    documentations
+                      ?.filter((doc: DocumentationRecord) => {
+                        const matches = !record.tagId || String(doc.tag_id) === record.tagId
+                        console.log('🔍 ADD MODE - Filtering documentation:', {
+                          docId: doc.id,
+                          docCode: doc.project_code,
+                          docTagId: doc.tag_id,
+                          recordTagId: record.tagId,
+                          matches,
+                          docTagName: doc.tag_name,
+                        })
+                        return matches
+                      })
+                      .map((doc: DocumentationRecord) => ({
+                        value: doc.id,
+                        label: doc.project_code,
+                      })) ?? []
+                  }
+                  disabled={!record.tagId}
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'material':
+              return (
+                <AutoComplete
+                  style={{ width: 300 }}
+                  options={materialOptions}
+                  value={record.material}
+                  onSelect={(value, option) => {
+                    handleRowChange(record.key, 'material', String(option?.label))
+                    handleRowChange(record.key, 'materialId', String(value))
+                  }}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'material', value)
+                    handleRowChange(record.key, 'materialId', '')
+                  }}
+                  onBlur={() => handleMaterialBlur(record.key, record.material)}
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'quantityPd':
+              return (
+                <Space>
+                  {parseFloorsString(record.floors).length > 1 && (
+                    <Button
+                      type="text"
+                      icon={<PlusOutlined />}
+                      onClick={() => openFloorModal(record.key, true)}
+                    />
+                  )}
+                  <Input
+                    style={{ width: '10ch' }}
+                    value={record.quantityPd}
+                    onChange={(e) => handleRowChange(record.key, 'quantityPd', e.target.value)}
                   />
-                )}
+                </Space>
+              )
+            case 'quantitySpec':
+              return (
                 <Input
                   style={{ width: '10ch' }}
-                  value={record.quantityPd}
-                  onChange={(e) => handleRowChange(record.key, 'quantityPd', e.target.value)}
+                  value={record.quantitySpec}
+                  onChange={(e) => handleRowChange(record.key, 'quantitySpec', e.target.value)}
                 />
-              </Space>
-            )
-          case 'quantitySpec':
-            return (
-              <Input
-                style={{ width: '10ch' }}
-                value={record.quantitySpec}
-                onChange={(e) => handleRowChange(record.key, 'quantitySpec', e.target.value)}
-              />
-            )
-          case 'quantityRd':
-            return (
-              <Input
-                style={{ width: '10ch' }}
-                value={record.quantityRd}
-                onChange={(e) => handleRowChange(record.key, 'quantityRd', e.target.value)}
-              />
-            )
-          case 'nomenclatureId':
-            return (
-              <Select
-                style={{ width: 250 }}
-                dropdownMatchSelectWidth={nomenclatureDropdownWidth}
-                value={record.nomenclatureId}
-                onChange={(value) => {
-                  handleRowChange(record.key, 'nomenclatureId', value)
-                  loadSupplierOptions(value, record.key)
-                  handleRowChange(record.key, 'supplier', '')
-                }}
-                options={getNomenclatureSelectOptions(record.nomenclatureId)}
-                showSearch
-                onSearch={handleNomenclatureSearch}
-                filterOption={false}
-                allowClear
-              />
-            )
-          case 'supplier':
-            return (
-              <Select
-                style={{ width: 250 }}
-                dropdownMatchSelectWidth={supplierDropdownWidths[record.key] ?? 250}
-                value={record.supplier || undefined}
-                onChange={(value) => handleRowChange(record.key, 'supplier', value)}
-                options={supplierOptions[record.key] ?? []}
-                disabled={!record.nomenclatureId}
-                showSearch
-                optionFilterProp="label"
-                allowClear
-              />
-            )
-          case 'unitId':
-            return (
-              <Select
-                style={{ width: 160 }}
-                value={record.unitId}
-                onChange={(value) => handleRowChange(record.key, 'unitId', value)}
-                options={units?.map((u) => ({ value: u.id, label: u.name })) ?? []}
-              />
-            )
-          case 'block':
-            return (
-              <Select
-                style={{ width: 120 }}
-                value={record.blockId}
-                onChange={(value) => {
-                  handleRowChange(record.key, 'blockId', value)
-                  const name = blocks?.find((b) => b.id === value)?.name ?? ''
-                  handleRowChange(record.key, 'block', name)
-                }}
-                options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
-              />
-            )
-          case 'floors':
-            return (
-              <Input
-                style={{ width: 150 }}
-                value={record.floors}
-                onChange={(e) => handleRowChange(record.key, 'floors', e.target.value)}
-                placeholder="1,2,3 или 1-5"
-              />
-            )
-          case 'costCategoryId':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={record.costCategoryId}
-                onChange={(value) => {
-                  handleRowChange(record.key, 'costCategoryId', value)
-                  handleRowChange(record.key, 'costTypeId', '')
-                  handleRowChange(record.key, 'locationId', '')
-                  handleRowChange(record.key, 'rateId', '')
-                }}
-                showSearch
-                optionFilterProp="label"
-                options={
-                  costCategories
-                    ?.filter(
-                      (c) => !appliedFilters?.categoryId || String(c.id) === appliedFilters.categoryId,
-                    )
-                    .map((c) => ({
-                      value: String(c.id),
-                      label: c.number ? `${c.number} ${c.name}` : c.name,
-                    })) ?? []
-                }
-              />
-            )
-          case 'costTypeId':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={record.costTypeId}
-                onChange={(value) => {
-                  handleRowChange(record.key, 'costTypeId', value)
-                  const loc = costTypes?.find((t) => t.id === Number(value))?.location_id
-                  handleRowChange(record.key, 'locationId', loc ? String(loc) : '')
-                  handleRowChange(record.key, 'rateId', '')
-                }}
-                showSearch
-                optionFilterProp="label"
-                options={
-                  costTypes
-                    ?.filter((t) => {
-                      const categoryId = record.costCategoryId || appliedFilters?.categoryId
-                      if (categoryId && t.cost_category_id !== Number(categoryId)) return false
-                      if (appliedFilters?.typeId) return String(t.id) === appliedFilters.typeId
-                      return true
-                    })
-                    .map((t) => ({ value: String(t.id), label: t.name })) ?? []
-                }
-              />
-            )
-          case 'rateId':
-            return (
-              <Select
-                style={{ width: 300 }}
-                value={record.rateId || undefined}
-                onChange={(value) => handleRowChange(record.key, 'rateId', value)}
-                options={getRateOptions(record.costTypeId, record.costCategoryId)}
-                placeholder="Наименование работ"
-                showSearch
-                optionFilterProp="label"
-                allowClear
-              />
-            )
-          case 'locationId':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={record.locationId}
-                onChange={(value) => handleRowChange(record.key, 'locationId', value)}
-                options={
-                  locations
-                    ?.filter((l) => {
-                      // Если выбран вид затрат, показываем только локализации, доступные для этого вида
-                      if (record.costTypeId) {
-                        const selectedType = costTypes?.find((t) => String(t.id) === record.costTypeId)
-                        if (selectedType) {
-                          // Находим все виды затрат с таким же названием
-                          const sameNameTypes = costTypes?.filter((t) => t.name === selectedType.name)
-                          // Получаем все location_id для этих видов затрат
-                          const availableLocationIds = sameNameTypes?.map((t) => String(t.location_id))
-                          return availableLocationIds?.includes(String(l.id))
+              )
+            case 'quantityRd':
+              return (
+                <Input
+                  style={{ width: '10ch' }}
+                  value={record.quantityRd}
+                  onChange={(e) => handleRowChange(record.key, 'quantityRd', e.target.value)}
+                />
+              )
+            case 'nomenclatureId':
+              return (
+                <Select
+                  style={{ width: 250 }}
+                  dropdownMatchSelectWidth={nomenclatureDropdownWidth}
+                  value={record.nomenclatureId}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'nomenclatureId', value)
+                    loadSupplierOptions(value, record.key)
+                    handleRowChange(record.key, 'supplier', '')
+                  }}
+                  options={getNomenclatureSelectOptions(record.nomenclatureId)}
+                  showSearch
+                  onSearch={handleNomenclatureSearch}
+                  filterOption={false}
+                  allowClear
+                />
+              )
+            case 'supplier':
+              return (
+                <Select
+                  style={{ width: 250 }}
+                  dropdownMatchSelectWidth={supplierDropdownWidths[record.key] ?? 250}
+                  value={record.supplier || undefined}
+                  onChange={(value) => handleRowChange(record.key, 'supplier', value)}
+                  options={supplierOptions[record.key] ?? []}
+                  disabled={!record.nomenclatureId}
+                  showSearch
+                  optionFilterProp="label"
+                  allowClear
+                />
+              )
+            case 'unitId':
+              return (
+                <Select
+                  style={{ width: 160 }}
+                  value={record.unitId}
+                  onChange={(value) => handleRowChange(record.key, 'unitId', value)}
+                  options={units?.map((u) => ({ value: u.id, label: u.name })) ?? []}
+                />
+              )
+            case 'block':
+              return (
+                <Select
+                  style={{ width: 120 }}
+                  value={record.blockId}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'blockId', value)
+                    const name = blocks?.find((b) => b.id === value)?.name ?? ''
+                    handleRowChange(record.key, 'block', name)
+                  }}
+                  options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
+                />
+              )
+            case 'floors':
+              return (
+                <Input
+                  style={{ width: 150 }}
+                  value={record.floors}
+                  onChange={(e) => handleRowChange(record.key, 'floors', e.target.value)}
+                  placeholder="1,2,3 или 1-5"
+                />
+              )
+            case 'costCategoryId':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={record.costCategoryId}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'costCategoryId', value)
+                    handleRowChange(record.key, 'costTypeId', '')
+                    handleRowChange(record.key, 'locationId', '')
+                    handleRowChange(record.key, 'rateId', '')
+                  }}
+                  showSearch
+                  optionFilterProp="label"
+                  options={
+                    costCategories
+                      ?.filter(
+                        (c) =>
+                          !appliedFilters?.categoryId || String(c.id) === appliedFilters.categoryId,
+                      )
+                      .map((c) => ({
+                        value: String(c.id),
+                        label: c.number ? `${c.number} ${c.name}` : c.name,
+                      })) ?? []
+                  }
+                />
+              )
+            case 'costTypeId':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={record.costTypeId}
+                  onChange={(value) => {
+                    handleRowChange(record.key, 'costTypeId', value)
+                    const loc = costTypes?.find((t) => t.id === Number(value))?.location_id
+                    handleRowChange(record.key, 'locationId', loc ? String(loc) : '')
+                    handleRowChange(record.key, 'rateId', '')
+                  }}
+                  showSearch
+                  optionFilterProp="label"
+                  options={
+                    costTypes
+                      ?.filter((t) => {
+                        const categoryId = record.costCategoryId || appliedFilters?.categoryId
+                        if (categoryId && t.cost_category_id !== Number(categoryId)) return false
+                        if (appliedFilters?.typeId) return String(t.id) === appliedFilters.typeId
+                        return true
+                      })
+                      .map((t) => ({ value: String(t.id), label: t.name })) ?? []
+                  }
+                />
+              )
+            case 'rateId':
+              return (
+                <Select
+                  style={{ width: 300 }}
+                  value={record.rateId || undefined}
+                  onChange={(value) => handleRowChange(record.key, 'rateId', value)}
+                  options={getRateOptions(record.costTypeId, record.costCategoryId)}
+                  placeholder="Наименование работ"
+                  showSearch
+                  optionFilterProp="label"
+                  allowClear
+                />
+              )
+            case 'locationId':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={record.locationId}
+                  onChange={(value) => handleRowChange(record.key, 'locationId', value)}
+                  options={
+                    locations
+                      ?.filter((l) => {
+                        // Если выбран вид затрат, показываем только локализации, доступные для этого вида
+                        if (record.costTypeId) {
+                          const selectedType = costTypes?.find(
+                            (t) => String(t.id) === record.costTypeId,
+                          )
+                          if (selectedType) {
+                            // Находим все виды затрат с таким же названием
+                            const sameNameTypes = costTypes?.filter(
+                              (t) => t.name === selectedType.name,
+                            )
+                            // Получаем все location_id для этих видов затрат
+                            const availableLocationIds = sameNameTypes?.map((t) =>
+                              String(t.location_id),
+                            )
+                            return availableLocationIds?.includes(String(l.id))
+                          }
                         }
-                      }
-                      // Если вид затрат не выбран, показываем все локализации
-                      return true
-                    })
-                    .map((l) => ({ value: String(l.id), label: l.name })) ?? []
-                }
-              />
-            )
-          default:
-            return null
+                        // Если вид затрат не выбран, показываем все локализации
+                        return true
+                      })
+                      .map((l) => ({ value: String(l.id), label: l.name })) ?? []
+                  }
+                />
+              )
+            default:
+              return null
+          }
         }
-      }
 
-      return { ...col, filters, filterSearch: true, sorter, onFilter, render }
-    })
+        return { ...col, filters, filterSearch: true, sorter, onFilter, render }
+      })
 
     return [
       {
@@ -2033,15 +2192,30 @@ export default function Chessboard() {
           index < rows.length ? (
             record.isExisting ? null : (
               <Space size={0}>
-                <RowColorPicker value={record.color} onChange={(c) => handleRowChange(record.key, 'color', c)} />
-                <Button type="text" size="small" icon={<PlusOutlined />} onClick={() => addRow(index)} style={{ padding: '2px 4px' }} />
-                <Button type="text" size="small" icon={<CopyOutlined />} onClick={() => copyRow(index)} style={{ padding: '2px 4px' }} />
-                <Button 
-                  type="text" 
+                <RowColorPicker
+                  value={record.color}
+                  onChange={(c) => handleRowChange(record.key, 'color', c)}
+                />
+                <Button
+                  type="text"
                   size="small"
-                  danger 
-                  icon={<DeleteOutlined />} 
-                  onClick={() => deleteRow(record.key)} 
+                  icon={<PlusOutlined />}
+                  onClick={() => addRow(index)}
+                  style={{ padding: '2px 4px' }}
+                />
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<CopyOutlined />}
+                  onClick={() => copyRow(index)}
+                  style={{ padding: '2px 4px' }}
+                />
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  icon={<DeleteOutlined />}
+                  onClick={() => deleteRow(record.key)}
                   style={{ padding: '2px 4px' }}
                 />
               </Space>
@@ -2085,29 +2259,33 @@ export default function Chessboard() {
     columnVisibility,
     columnOrder,
     nomenclatureDropdownWidth,
-      getRateOptions,
-      openFloorModal,
+    getRateOptions,
+    openFloorModal,
     supplierOptions,
     supplierDropdownWidths,
     loadSupplierOptions,
     getNomenclatureSelectOptions,
+    materialOptions,
+    handleMaterialBlur,
   ])
 
   const viewColumns: ColumnsType<ViewRow> = useMemo(() => {
     // Чекбокс колонка для режима удаления
-    const checkboxColumn: ColumnType<ViewRow> | null = deleteMode ? {
-      title: '',
-      dataIndex: 'checkbox',
-      width: 50,
-      fixed: 'left',
-      render: (_: unknown, record: ViewRow) => (
-        <Checkbox
-          checked={selectedRows.has(record.key)}
-          onChange={() => toggleRowSelection(record.key)}
-        />
-      ),
-    } : null
-    
+    const checkboxColumn: ColumnType<ViewRow> | null = deleteMode
+      ? {
+          title: '',
+          dataIndex: 'checkbox',
+          width: 50,
+          fixed: 'left',
+          render: (_: unknown, record: ViewRow) => (
+            <Checkbox
+              checked={selectedRows.has(record.key)}
+              onChange={() => toggleRowSelection(record.key)}
+            />
+          ),
+        }
+      : null
+
     const base: Array<{
       title: string
       dataIndex: string
@@ -2156,331 +2334,365 @@ export default function Chessboard() {
         return aIndex - bIndex
       })
       .map((col) => {
-      const values = Array.from(
-        new Set(viewRows.map((row) => row[col.dataIndex as keyof ViewRow]).filter((v) => v)),
-      )
-      const filters = values.map((v) => ({ text: String(v), value: String(v) }))
+        const values = Array.from(
+          new Set(viewRows.map((row) => row[col.dataIndex as keyof ViewRow]).filter((v) => v)),
+        )
+        const filters = values.map((v) => ({ text: String(v), value: String(v) }))
 
-      const render: ColumnType<ViewRow>['render'] = (_, record) => {
-        const edit = editingRows[record.key]
-        if (!edit) {
-          if (
-            ['quantityPd', 'quantitySpec', 'quantityRd'].includes(col.dataIndex) &&
-            parseFloorsString(record.floors).length > 1 &&
-            record[col.dataIndex as keyof ViewRow]
-          ) {
-            return (
-              <Button
-                type="link"
-                style={{ padding: 0 }}
-                onClick={() => openFloorModal(record.key, false)}
-              >
-                {record[col.dataIndex as keyof ViewRow]}
-              </Button>
-            )
+        const render: ColumnType<ViewRow>['render'] = (_, record) => {
+          const edit = editingRows[record.key]
+          if (!edit) {
+            if (
+              ['quantityPd', 'quantitySpec', 'quantityRd'].includes(col.dataIndex) &&
+              parseFloorsString(record.floors).length > 1 &&
+              record[col.dataIndex as keyof ViewRow]
+            ) {
+              return (
+                <Button
+                  type="link"
+                  style={{ padding: 0 }}
+                  onClick={() => openFloorModal(record.key, false)}
+                >
+                  {record[col.dataIndex as keyof ViewRow]}
+                </Button>
+              )
+            }
+            return record[col.dataIndex as keyof ViewRow]
           }
-          return record[col.dataIndex as keyof ViewRow]
-        }
-        switch (col.dataIndex) {
-          case 'tagName':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={edit.tagId}
-                onChange={(value) => {
-                  handleEditChange(record.key, 'tagId', value)
-                  const tag = documentationTags?.find((t) => String(t.id) === value)
-                  handleEditChange(record.key, 'tagName', tag ? `${tag.tag_number || ''} ${tag.name}`.trim() : '')
-                  // Сбрасываем выбранный документ при смене тэга
-                  handleEditChange(record.key, 'documentationId', '')
-                  handleEditChange(record.key, 'projectCode', '')
-                }}
-                options={
-                  documentationTags?.map((tag) => ({
-                    value: String(tag.id),
-                    label: `${tag.tag_number || ''} ${tag.name}`.trim()
-                  })) ?? []
-                }
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-            )
-          case 'projectCode':
-            return (
-              <Select
-                style={{ width: 150 }}
-                value={edit.documentationId}
-                onDropdownVisibleChange={(open) => {
-                  if (open) {
-                    const filteredDocs = documentations?.filter((doc: DocumentationRecord) => !edit.tagId || String(doc.tag_id) === edit.tagId) ?? []
-                    console.log('🔽 EDIT MODE - Project Code dropdown opened:', {
-                      recordKey: record.key,
-                      tagId: edit.tagId,
-                      totalDocs: documentations?.length ?? 0,
-                      filteredDocs: filteredDocs.length,
-                      availableOptions: filteredDocs.length
-                    })
-                  }
-                }}
-                onChange={(value) => {
-                  console.log('✏️ EDIT MODE - Project Code selected:', { value, recordKey: record.key })
-                  handleEditChange(record.key, 'documentationId', value)
-                  const doc = documentations?.find((d: DocumentationRecord) => d.id === value)
-                  handleEditChange(record.key, 'projectCode', doc?.project_code ?? '')
-                }}
-                options={
-                  documentations
-                    ?.filter((doc: DocumentationRecord) => {
-                      const matches = !edit.tagId || String(doc.tag_id) === edit.tagId
-                      console.log('🔍 EDIT MODE - Filtering documentation:', {
-                        docId: doc.id,
-                        docCode: doc.project_code,
-                        docTagId: doc.tag_id,
-                        editTagId: edit.tagId,
-                        matches,
-                        docTagName: doc.tag_name
-                      })
-                      return matches
-                    })
-                    .map((doc: DocumentationRecord) => ({
-                      value: doc.id,
-                      label: doc.project_code
+          switch (col.dataIndex) {
+            case 'tagName':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={edit.tagId}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'tagId', value)
+                    const tag = documentationTags?.find((t) => String(t.id) === value)
+                    handleEditChange(
+                      record.key,
+                      'tagName',
+                      tag ? `${tag.tag_number || ''} ${tag.name}`.trim() : '',
+                    )
+                    // Сбрасываем выбранный документ при смене тэга
+                    handleEditChange(record.key, 'documentationId', '')
+                    handleEditChange(record.key, 'projectCode', '')
+                  }}
+                  options={
+                    documentationTags?.map((tag) => ({
+                      value: String(tag.id),
+                      label: `${tag.tag_number || ''} ${tag.name}`.trim(),
                     })) ?? []
-                }
-                disabled={!edit.tagId}
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-            )
-         case 'material':
-            return (
-              <Input
-                style={{ width: 300 }}
-                value={edit.material}
-                onChange={(e) => handleEditChange(record.key, 'material', e.target.value)}
-              />
-            )
-          case 'quantityPd':
-            return (
-              <Space>
-                {parseFloorsString(edit.floors).length > 1 && (
-                  <Button
-                    type="text"
-                    icon={<PlusOutlined />}
-                    onClick={() => openFloorModal(record.key, true)}
+                  }
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'projectCode':
+              return (
+                <Select
+                  style={{ width: 150 }}
+                  value={edit.documentationId}
+                  onDropdownVisibleChange={(open) => {
+                    if (open) {
+                      const filteredDocs =
+                        documentations?.filter(
+                          (doc: DocumentationRecord) =>
+                            !edit.tagId || String(doc.tag_id) === edit.tagId,
+                        ) ?? []
+                      console.log('🔽 EDIT MODE - Project Code dropdown opened:', {
+                        recordKey: record.key,
+                        tagId: edit.tagId,
+                        totalDocs: documentations?.length ?? 0,
+                        filteredDocs: filteredDocs.length,
+                        availableOptions: filteredDocs.length,
+                      })
+                    }
+                  }}
+                  onChange={(value) => {
+                    console.log('✏️ EDIT MODE - Project Code selected:', {
+                      value,
+                      recordKey: record.key,
+                    })
+                    handleEditChange(record.key, 'documentationId', value)
+                    const doc = documentations?.find((d: DocumentationRecord) => d.id === value)
+                    handleEditChange(record.key, 'projectCode', doc?.project_code ?? '')
+                  }}
+                  options={
+                    documentations
+                      ?.filter((doc: DocumentationRecord) => {
+                        const matches = !edit.tagId || String(doc.tag_id) === edit.tagId
+                        console.log('🔍 EDIT MODE - Filtering documentation:', {
+                          docId: doc.id,
+                          docCode: doc.project_code,
+                          docTagId: doc.tag_id,
+                          editTagId: edit.tagId,
+                          matches,
+                          docTagName: doc.tag_name,
+                        })
+                        return matches
+                      })
+                      .map((doc: DocumentationRecord) => ({
+                        value: doc.id,
+                        label: doc.project_code,
+                      })) ?? []
+                  }
+                  disabled={!edit.tagId}
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'material':
+              return (
+                <AutoComplete
+                  style={{ width: 300 }}
+                  options={materialOptions}
+                  value={edit.material}
+                  onSelect={(value, option) => {
+                    handleEditChange(record.key, 'material', String(option?.label))
+                    handleEditChange(record.key, 'materialId', String(value))
+                  }}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'material', value)
+                    handleEditChange(record.key, 'materialId', '')
+                  }}
+                  onBlur={() => handleMaterialBlur(record.key, edit.material)}
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+              )
+            case 'quantityPd':
+              return (
+                <Space>
+                  {parseFloorsString(edit.floors).length > 1 && (
+                    <Button
+                      type="text"
+                      icon={<PlusOutlined />}
+                      onClick={() => openFloorModal(record.key, true)}
+                    />
+                  )}
+                  <Input
+                    style={{ width: '10ch' }}
+                    value={edit.quantityPd}
+                    onChange={(e) => handleEditChange(record.key, 'quantityPd', e.target.value)}
                   />
-                )}
+                </Space>
+              )
+            case 'quantitySpec':
+              return (
                 <Input
                   style={{ width: '10ch' }}
-                  value={edit.quantityPd}
-                  onChange={(e) => handleEditChange(record.key, 'quantityPd', e.target.value)}
+                  value={edit.quantitySpec}
+                  onChange={(e) => handleEditChange(record.key, 'quantitySpec', e.target.value)}
                 />
-              </Space>
-            )
-          case 'quantitySpec':
-            return (
-              <Input
-                style={{ width: '10ch' }}
-                value={edit.quantitySpec}
-                onChange={(e) => handleEditChange(record.key, 'quantitySpec', e.target.value)}
-              />
-            )
-          case 'quantityRd':
-            return (
-              <Input
-                style={{ width: '10ch' }}
-                value={edit.quantityRd}
-                onChange={(e) => handleEditChange(record.key, 'quantityRd', e.target.value)}
-              />
-            )
-          case 'nomenclature':
-            return (
-              <Select
-                style={{ width: 250 }}
-                dropdownMatchSelectWidth={nomenclatureDropdownWidth}
-                value={edit.nomenclatureId}
-                onChange={(value) => {
-                  handleEditChange(record.key, 'nomenclatureId', value)
-                  loadSupplierOptions(value, record.key)
-                  handleEditChange(record.key, 'supplier', '')
-                }}
-                options={getNomenclatureSelectOptions(edit.nomenclatureId, record.nomenclature)}
-                showSearch
-                onSearch={handleNomenclatureSearch}
-                filterOption={false}
-                allowClear
-              />
-            )
-          case 'supplier':
-            return (
-              <Select
-                style={{ width: 250 }}
-                dropdownMatchSelectWidth={supplierDropdownWidths[record.key] ?? 250}
-                value={edit.supplier || undefined}
-                onChange={(value) => handleEditChange(record.key, 'supplier', value)}
-                options={supplierOptions[record.key] ?? []}
-                disabled={!edit.nomenclatureId}
-                showSearch
-                optionFilterProp="label"
-                allowClear
-              />
-            )
-          case 'unit':
-            return (
-              <Select
-                style={{ width: 160 }}
-                value={edit.unitId}
-                onChange={(value) => handleEditChange(record.key, 'unitId', value)}
-                options={units?.map((u) => ({ value: u.id, label: u.name })) ?? []}
-              />
-            )
-          case 'block':
-            return (
-              <Select
-                style={{ width: 120 }}
-                value={edit.blockId}
-                onChange={(value) => {
-                  handleEditChange(record.key, 'blockId', value)
-                  const name = blocks?.find((b) => b.id === value)?.name ?? ''
-                  handleEditChange(record.key, 'block', name)
-                }}
-                options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
-              />
-            )
-          case 'floors':
-            return (
-              <Input
-                style={{ width: 150 }}
-                value={edit.floors}
-                onChange={(e) => handleEditChange(record.key, 'floors', e.target.value)}
-                placeholder="1,2,3 или 1-5"
-              />
-            )
-          case 'costCategory':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={edit.costCategoryId}
-                onChange={(value) => {
-                  handleEditChange(record.key, 'costCategoryId', value)
-                  handleEditChange(record.key, 'costTypeId', '')
-                  handleEditChange(record.key, 'locationId', '')
-                  handleEditChange(record.key, 'rateId', '')
-                }}
-                popupMatchSelectWidth={false}
-                showSearch
-                optionFilterProp="label"
-                options={
-                  costCategories
-                    ?.sort((a, b) => {
-                      // Сортируем по номеру, если он есть
-                      if (a.number !== undefined && a.number !== null && 
-                          b.number !== undefined && b.number !== null) {
-                        // Числовое сравнение для правильной сортировки
-                        return Number(a.number) - Number(b.number)
-                      }
-                      return a.name.localeCompare(b.name)
-                    })
-                    .map((c) => ({
-                      value: String(c.id),
-                      label: c.name, // Отображаем только название без номера
-                    })) ?? []
-                }
-              />
-            )
-          case 'costType':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={edit.costTypeId}
-                onChange={(value) => {
-                  handleEditChange(record.key, 'costTypeId', value)
-                  const loc = costTypes?.find((t) => t.id === Number(value))?.location_id
-                  handleEditChange(record.key, 'locationId', loc ? String(loc) : '')
-                  handleEditChange(record.key, 'rateId', '')
-                }}
-                showSearch
-                optionFilterProp="label"
-                options={
-                  costTypes
-                    ?.filter((t) => t.cost_category_id === Number(edit.costCategoryId))
-                    .map((t) => ({ value: String(t.id), label: t.name })) ?? []
-                }
-              />
-            )
-          case 'workName':
-            return (
-              <Select
-                style={{ width: 300 }}
-                value={edit.rateId || undefined}
-                onChange={(value) => handleEditChange(record.key, 'rateId', value)}
-                options={getRateOptions(edit.costTypeId, edit.costCategoryId)}
-                placeholder="Наименование работ"
-                showSearch
-                optionFilterProp="label"
-                allowClear
-              />
-            )
-          case 'location':
-            return (
-              <Select
-                style={{ width: 200 }}
-                value={edit.locationId}
-                onChange={(value) => handleEditChange(record.key, 'locationId', value)}
-                options={
-                  locations
-                    ?.filter((l) => {
-                      // Если выбран вид затрат, показываем только локализации, доступные для этого вида
-                      if (edit.costTypeId) {
-                        const selectedType = costTypes?.find((t) => String(t.id) === edit.costTypeId)
-                        if (selectedType) {
-                          // Находим все виды затрат с таким же названием
-                          const sameNameTypes = costTypes?.filter((t) => t.name === selectedType.name)
-                          // Получаем все location_id для этих видов затрат
-                          const availableLocationIds = sameNameTypes?.map((t) => String(t.location_id))
-                          return availableLocationIds?.includes(String(l.id))
+              )
+            case 'quantityRd':
+              return (
+                <Input
+                  style={{ width: '10ch' }}
+                  value={edit.quantityRd}
+                  onChange={(e) => handleEditChange(record.key, 'quantityRd', e.target.value)}
+                />
+              )
+            case 'nomenclature':
+              return (
+                <Select
+                  style={{ width: 250 }}
+                  dropdownMatchSelectWidth={nomenclatureDropdownWidth}
+                  value={edit.nomenclatureId}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'nomenclatureId', value)
+                    loadSupplierOptions(value, record.key)
+                    handleEditChange(record.key, 'supplier', '')
+                  }}
+                  options={getNomenclatureSelectOptions(edit.nomenclatureId, record.nomenclature)}
+                  showSearch
+                  onSearch={handleNomenclatureSearch}
+                  filterOption={false}
+                  allowClear
+                />
+              )
+            case 'supplier':
+              return (
+                <Select
+                  style={{ width: 250 }}
+                  dropdownMatchSelectWidth={supplierDropdownWidths[record.key] ?? 250}
+                  value={edit.supplier || undefined}
+                  onChange={(value) => handleEditChange(record.key, 'supplier', value)}
+                  options={supplierOptions[record.key] ?? []}
+                  disabled={!edit.nomenclatureId}
+                  showSearch
+                  optionFilterProp="label"
+                  allowClear
+                />
+              )
+            case 'unit':
+              return (
+                <Select
+                  style={{ width: 160 }}
+                  value={edit.unitId}
+                  onChange={(value) => handleEditChange(record.key, 'unitId', value)}
+                  options={units?.map((u) => ({ value: u.id, label: u.name })) ?? []}
+                />
+              )
+            case 'block':
+              return (
+                <Select
+                  style={{ width: 120 }}
+                  value={edit.blockId}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'blockId', value)
+                    const name = blocks?.find((b) => b.id === value)?.name ?? ''
+                    handleEditChange(record.key, 'block', name)
+                  }}
+                  options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
+                />
+              )
+            case 'floors':
+              return (
+                <Input
+                  style={{ width: 150 }}
+                  value={edit.floors}
+                  onChange={(e) => handleEditChange(record.key, 'floors', e.target.value)}
+                  placeholder="1,2,3 или 1-5"
+                />
+              )
+            case 'costCategory':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={edit.costCategoryId}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'costCategoryId', value)
+                    handleEditChange(record.key, 'costTypeId', '')
+                    handleEditChange(record.key, 'locationId', '')
+                    handleEditChange(record.key, 'rateId', '')
+                  }}
+                  popupMatchSelectWidth={false}
+                  showSearch
+                  optionFilterProp="label"
+                  options={
+                    costCategories
+                      ?.sort((a, b) => {
+                        // Сортируем по номеру, если он есть
+                        if (
+                          a.number !== undefined &&
+                          a.number !== null &&
+                          b.number !== undefined &&
+                          b.number !== null
+                        ) {
+                          // Числовое сравнение для правильной сортировки
+                          return Number(a.number) - Number(b.number)
                         }
-                      }
-                      // Если вид затрат не выбран, показываем все локализации
-                      return true
-                    })
-                    .map((l) => ({ value: String(l.id), label: l.name })) ?? []
-                }
-              />
-            )
-          default:
-            return record[col.dataIndex as keyof ViewRow]
+                        return a.name.localeCompare(b.name)
+                      })
+                      .map((c) => ({
+                        value: String(c.id),
+                        label: c.name, // Отображаем только название без номера
+                      })) ?? []
+                  }
+                />
+              )
+            case 'costType':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={edit.costTypeId}
+                  onChange={(value) => {
+                    handleEditChange(record.key, 'costTypeId', value)
+                    const loc = costTypes?.find((t) => t.id === Number(value))?.location_id
+                    handleEditChange(record.key, 'locationId', loc ? String(loc) : '')
+                    handleEditChange(record.key, 'rateId', '')
+                  }}
+                  showSearch
+                  optionFilterProp="label"
+                  options={
+                    costTypes
+                      ?.filter((t) => t.cost_category_id === Number(edit.costCategoryId))
+                      .map((t) => ({ value: String(t.id), label: t.name })) ?? []
+                  }
+                />
+              )
+            case 'workName':
+              return (
+                <Select
+                  style={{ width: 300 }}
+                  value={edit.rateId || undefined}
+                  onChange={(value) => handleEditChange(record.key, 'rateId', value)}
+                  options={getRateOptions(edit.costTypeId, edit.costCategoryId)}
+                  placeholder="Наименование работ"
+                  showSearch
+                  optionFilterProp="label"
+                  allowClear
+                />
+              )
+            case 'location':
+              return (
+                <Select
+                  style={{ width: 200 }}
+                  value={edit.locationId}
+                  onChange={(value) => handleEditChange(record.key, 'locationId', value)}
+                  options={
+                    locations
+                      ?.filter((l) => {
+                        // Если выбран вид затрат, показываем только локализации, доступные для этого вида
+                        if (edit.costTypeId) {
+                          const selectedType = costTypes?.find(
+                            (t) => String(t.id) === edit.costTypeId,
+                          )
+                          if (selectedType) {
+                            // Находим все виды затрат с таким же названием
+                            const sameNameTypes = costTypes?.filter(
+                              (t) => t.name === selectedType.name,
+                            )
+                            // Получаем все location_id для этих видов затрат
+                            const availableLocationIds = sameNameTypes?.map((t) =>
+                              String(t.location_id),
+                            )
+                            return availableLocationIds?.includes(String(l.id))
+                          }
+                        }
+                        // Если вид затрат не выбран, показываем все локализации
+                        return true
+                      })
+                      .map((l) => ({ value: String(l.id), label: l.name })) ?? []
+                  }
+                />
+              )
+            default:
+              return record[col.dataIndex as keyof ViewRow]
+          }
         }
-      }
 
-      return {
-        ...col,
-        filterSearch: true,
-        sorter: (a: ViewRow, b: ViewRow) => {
-          const dataIndex = col.dataIndex as keyof ViewRow
-          const aVal = a[dataIndex]
-          const bVal = b[dataIndex]
-          const aNum = Number(aVal)
-          const bNum = Number(bVal)
-          if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
-          return String(aVal ?? '').localeCompare(String(bVal ?? ''))
-        },
-        filters,
-        onFilter: (value: boolean | Key, record: ViewRow) => {
-          const dataIndex = col.dataIndex as keyof ViewRow
-          return String(record[dataIndex] ?? '') === String(value)
-        },
-        render,
-      }
-    })
+        return {
+          ...col,
+          filterSearch: true,
+          sorter: (a: ViewRow, b: ViewRow) => {
+            const dataIndex = col.dataIndex as keyof ViewRow
+            const aVal = a[dataIndex]
+            const bVal = b[dataIndex]
+            const aNum = Number(aVal)
+            const bNum = Number(bVal)
+            if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
+            return String(aVal ?? '').localeCompare(String(bVal ?? ''))
+          },
+          filters,
+          onFilter: (value: boolean | Key, record: ViewRow) => {
+            const dataIndex = col.dataIndex as keyof ViewRow
+            return String(record[dataIndex] ?? '') === String(value)
+          },
+          render,
+        }
+      })
 
     const finalColumns = [
       {
@@ -2490,7 +2702,10 @@ export default function Chessboard() {
         render: (_: unknown, record: ViewRow) => {
           const edit = editingRows[record.key]
           return edit ? (
-            <RowColorPicker value={edit.color} onChange={(c) => handleEditChange(record.key, 'color', c)} />
+            <RowColorPicker
+              value={edit.color}
+              onChange={(c) => handleEditChange(record.key, 'color', c)}
+            />
           ) : (
             <div
               style={{
@@ -2522,7 +2737,7 @@ export default function Chessboard() {
         },
       },
     ]
-    
+
     // Добавляем checkbox колонку в начало если включен режим удаления
     return checkboxColumn ? [checkboxColumn, ...finalColumns] : finalColumns
   }, [
@@ -2551,28 +2766,33 @@ export default function Chessboard() {
     supplierDropdownWidths,
     loadSupplierOptions,
     getNomenclatureSelectOptions,
+    materialOptions,
+    handleMaterialBlur,
   ])
 
   const { Text } = Typography
 
   // Инициализация порядка и видимости столбцов
-  const allColumns = useMemo(() => [
-    { key: 'tagName', title: 'Раздел' },
-    { key: 'projectCode', title: 'Шифр проекта' },
-    { key: 'block', title: 'Корпус' },
-    { key: 'floors', title: 'Этажи' },
-    { key: 'costCategory', title: 'Категория затрат' },
-    { key: 'costType', title: 'Вид затрат' },
-    { key: 'workName', title: 'Наименование работ' },
-    { key: 'location', title: 'Локализация' },
-    { key: 'material', title: 'Материал' },
-    { key: 'quantityPd', title: 'Кол-во по ПД' },
-    { key: 'quantitySpec', title: 'Кол-во по спеке РД' },
-    { key: 'quantityRd', title: 'Кол-во по пересчету РД' },
-    { key: 'nomenclature', title: 'Номенклатура' },
-    { key: 'supplier', title: 'Наименование поставщика' },
-    { key: 'unit', title: 'Ед.изм.' },
-  ], [])
+  const allColumns = useMemo(
+    () => [
+      { key: 'tagName', title: 'Раздел' },
+      { key: 'projectCode', title: 'Шифр проекта' },
+      { key: 'block', title: 'Корпус' },
+      { key: 'floors', title: 'Этажи' },
+      { key: 'costCategory', title: 'Категория затрат' },
+      { key: 'costType', title: 'Вид затрат' },
+      { key: 'workName', title: 'Наименование работ' },
+      { key: 'location', title: 'Локализация' },
+      { key: 'material', title: 'Материал' },
+      { key: 'quantityPd', title: 'Кол-во по ПД' },
+      { key: 'quantitySpec', title: 'Кол-во по спеке РД' },
+      { key: 'quantityRd', title: 'Кол-во по пересчету РД' },
+      { key: 'nomenclature', title: 'Номенклатура' },
+      { key: 'supplier', title: 'Наименование поставщика' },
+      { key: 'unit', title: 'Ед.изм.' },
+    ],
+    [],
+  )
 
   // Инициализация состояния видимости столбцов при первой загрузке
   useMemo(() => {
@@ -2581,13 +2801,13 @@ export default function Chessboard() {
     // Сброс устаревшего ключа порядка столбцов
     localStorage.removeItem('chessboard-column-order')
     const savedOrder = localStorage.getItem('chessboard-column-order-v2')
-    
+
     if (savedVisibility && Object.keys(columnVisibility).length === 0) {
       try {
         const parsed = JSON.parse(savedVisibility)
         // Проверяем, есть ли новые столбцы, которых нет в сохраненных настройках
         let hasNewColumns = false
-        allColumns.forEach(col => {
+        allColumns.forEach((col) => {
           if (!(col.key in parsed)) {
             parsed[col.key] = true
             hasNewColumns = true
@@ -2600,30 +2820,30 @@ export default function Chessboard() {
         }
       } catch {
         const initialVisibility: Record<string, boolean> = {}
-        allColumns.forEach(col => {
+        allColumns.forEach((col) => {
           initialVisibility[col.key] = true
         })
         setColumnVisibility(initialVisibility)
       }
     } else if (Object.keys(columnVisibility).length === 0) {
       const initialVisibility: Record<string, boolean> = {}
-      allColumns.forEach(col => {
+      allColumns.forEach((col) => {
         initialVisibility[col.key] = true
       })
       setColumnVisibility(initialVisibility)
     }
-    
+
     if (savedOrder && columnOrder.length === 0) {
       try {
         const parsed = JSON.parse(savedOrder)
         // Добавляем новые столбцы, которых нет в сохраненном порядке
-        const missingColumns = allColumns.filter(col => !parsed.includes(col.key))
+        const missingColumns = allColumns.filter((col) => !parsed.includes(col.key))
         // Добавляем новые столбцы в начало (tagName и projectCode должны быть первыми)
         if (missingColumns.length > 0) {
-          const tagNameCol = missingColumns.find(c => c.key === 'tagName')
-          const projectCodeCol = missingColumns.find(c => c.key === 'projectCode')
+          const tagNameCol = missingColumns.find((c) => c.key === 'tagName')
+          const projectCodeCol = missingColumns.find((c) => c.key === 'projectCode')
           const newOrder = []
-          
+
           // Добавляем tagName и projectCode в начало
           if (tagNameCol) {
             newOrder.push('tagName')
@@ -2633,13 +2853,13 @@ export default function Chessboard() {
             newOrder.push('projectCode')
             missingColumns.splice(missingColumns.indexOf(projectCodeCol), 1)
           }
-          
+
           // Затем все остальные существующие столбцы
           newOrder.push(...parsed)
-          
+
           // И оставшиеся новые столбцы в конец
-          newOrder.push(...missingColumns.map(c => c.key))
-          
+          newOrder.push(...missingColumns.map((c) => c.key))
+
           setColumnOrder(newOrder)
           // Обновляем localStorage
           localStorage.setItem('chessboard-column-order-v2', JSON.stringify(newOrder))
@@ -2647,20 +2867,20 @@ export default function Chessboard() {
           setColumnOrder(parsed)
         }
       } catch {
-        setColumnOrder(allColumns.map(c => c.key))
+        setColumnOrder(allColumns.map((c) => c.key))
       }
     } else if (columnOrder.length === 0) {
-      setColumnOrder(allColumns.map(c => c.key))
+      setColumnOrder(allColumns.map((c) => c.key))
     }
   }, [allColumns, columnVisibility, columnOrder])
-  
+
   // Сохранение в localStorage при изменении
   useMemo(() => {
     if (Object.keys(columnVisibility).length > 0) {
       localStorage.setItem('chessboard-column-visibility', JSON.stringify(columnVisibility))
     }
   }, [columnVisibility])
-  
+
   useMemo(() => {
     if (columnOrder.length > 0) {
       localStorage.setItem('chessboard-column-order-v2', JSON.stringify(columnOrder))
@@ -2668,46 +2888,49 @@ export default function Chessboard() {
   }, [columnOrder])
 
   const moveColumn = useCallback((key: string, direction: 'up' | 'down') => {
-    setColumnOrder(prev => {
+    setColumnOrder((prev) => {
       const index = prev.indexOf(key)
       if (index === -1) return prev
-      
+
       const newOrder = [...prev]
       if (direction === 'up' && index > 0) {
-        [newOrder[index - 1], newOrder[index]] = [newOrder[index], newOrder[index - 1]]
+        ;[newOrder[index - 1], newOrder[index]] = [newOrder[index], newOrder[index - 1]]
       } else if (direction === 'down' && index < prev.length - 1) {
-        [newOrder[index], newOrder[index + 1]] = [newOrder[index + 1], newOrder[index]]
+        ;[newOrder[index], newOrder[index + 1]] = [newOrder[index + 1], newOrder[index]]
       }
       return newOrder
     })
   }, [])
 
   const toggleColumnVisibility = useCallback((key: string) => {
-    setColumnVisibility(prev => ({
+    setColumnVisibility((prev) => ({
       ...prev,
-      [key]: !prev[key]
+      [key]: !prev[key],
     }))
   }, [])
-  
-  const selectAllColumns = useCallback((select: boolean) => {
-    const newVisibility: Record<string, boolean> = {}
-    allColumns.forEach(col => {
-      newVisibility[col.key] = select
-    })
-    setColumnVisibility(newVisibility)
-  }, [allColumns])
-  
+
+  const selectAllColumns = useCallback(
+    (select: boolean) => {
+      const newVisibility: Record<string, boolean> = {}
+      allColumns.forEach((col) => {
+        newVisibility[col.key] = select
+      })
+      setColumnVisibility(newVisibility)
+    },
+    [allColumns],
+  )
+
   const resetToDefaults = useCallback(() => {
     // Сброс видимости - все столбцы видимы
     const defaultVisibility: Record<string, boolean> = {}
-    allColumns.forEach(col => {
+    allColumns.forEach((col) => {
       defaultVisibility[col.key] = true
     })
     setColumnVisibility(defaultVisibility)
-    
+
     // Сброс порядка - исходный порядок
-    setColumnOrder(allColumns.map(c => c.key))
-    
+    setColumnOrder(allColumns.map((c) => c.key))
+
     // Очистка localStorage
     localStorage.removeItem('chessboard-column-visibility')
     localStorage.removeItem('chessboard-column-order')
@@ -2717,8 +2940,8 @@ export default function Chessboard() {
   // Применение порядка и видимости к столбцам таблицы
   const orderedViewColumns = useMemo(() => {
     const columnsMap: Record<string, ColumnType<ViewRow>> = {}
-    
-    viewColumns.forEach(col => {
+
+    viewColumns.forEach((col) => {
       if (col && 'dataIndex' in col) {
         columnsMap[col.dataIndex as string] = col
       }
@@ -2727,56 +2950,64 @@ export default function Chessboard() {
     // Служебные столбцы
     const actionsColumn = columnsMap['actions']
     const colorColumn = columnsMap['color']
-    
+
     // Сначала фильтруем столбцы по видимости и порядку
     const orderedCols = columnOrder
-      .filter(key => {
+      .filter((key) => {
         // Служебные колонки не включаем в основную сортировку
-        if (key === 'checkbox' || key === 'color' || key === 'actions' || key === 'add') return false
+        if (key === 'checkbox' || key === 'color' || key === 'actions' || key === 'add')
+          return false
         return columnVisibility[key] !== false
       })
-      .map(key => columnsMap[key])
+      .map((key) => columnsMap[key])
       .filter(Boolean)
-    
+
     // Собираем результат
     const result = []
-    
+
     // Если включен режим удаления, добавляем checkbox колонку в начало
     if (deleteMode && columnsMap['checkbox']) {
       result.push(columnsMap['checkbox'])
     }
-    
+
     // Добавляем цветовую колонку если она есть
     if (colorColumn) {
       result.push(colorColumn)
     }
-    
+
     // Добавляем отсортированные колонки данных
     result.push(...orderedCols)
-    
+
     // Добавляем колонку действий в конец
     if (actionsColumn) {
       result.push(actionsColumn)
     }
-    
+
     return result
   }, [viewColumns, columnOrder, columnVisibility, deleteMode])
 
   // Применение порядка и видимости к addColumns
   const orderedAddColumns = useMemo(() => {
     const columnsMap: Record<string, ColumnType<TableRow>> = {}
-    
-    addColumns.forEach(col => {
+
+    addColumns.forEach((col) => {
       if (col && 'dataIndex' in col) {
         const dataIndex = col.dataIndex as string
         // Маппинг для соответствия между addColumns и настройками столбцов
-        const mappedKey = dataIndex === 'unitId' ? 'unit' :
-                          dataIndex === 'costCategoryId' ? 'costCategory' :
-                          dataIndex === 'costTypeId' ? 'costType' :
-                          dataIndex === 'locationId' ? 'location' :
-                          dataIndex === 'rateId' ? 'workName' :
-                          dataIndex === 'nomenclatureId' ? 'nomenclature' :
-                          dataIndex
+        const mappedKey =
+          dataIndex === 'unitId'
+            ? 'unit'
+            : dataIndex === 'costCategoryId'
+              ? 'costCategory'
+              : dataIndex === 'costTypeId'
+                ? 'costType'
+                : dataIndex === 'locationId'
+                  ? 'location'
+                  : dataIndex === 'rateId'
+                    ? 'workName'
+                    : dataIndex === 'nomenclatureId'
+                      ? 'nomenclature'
+                      : dataIndex
         columnsMap[mappedKey] = col
       }
     })
@@ -2784,30 +3015,34 @@ export default function Chessboard() {
     // Служебные колонки (действия) всегда добавляются в начало и конец
     const actionsColumn = columnsMap['actions']
     const editActionsColumn = columnsMap['editActions']
-    
+
     // Применяем порядок и видимость к остальным колонкам
     const orderedDataCols = columnOrder
-      .filter(key => {
-        return columnVisibility[key] !== false && columnsMap[key] && 
-               key !== 'actions' && key !== 'editActions'
+      .filter((key) => {
+        return (
+          columnVisibility[key] !== false &&
+          columnsMap[key] &&
+          key !== 'actions' &&
+          key !== 'editActions'
+        )
       })
-      .map(key => columnsMap[key])
+      .map((key) => columnsMap[key])
       .filter(Boolean)
-    
+
     // Собираем итоговый массив колонок
     const result = []
     if (actionsColumn) result.push(actionsColumn)
     result.push(...orderedDataCols)
     if (editActionsColumn) result.push(editActionsColumn)
-    
+
     return result
   }, [addColumns, columnOrder, columnVisibility])
 
   const handleExport = useCallback(() => {
-    const data = viewRows.map(row => {
+    const data = viewRows.map((row) => {
       const record: Record<string, string> = {}
       const rowRecord = row as unknown as Record<string, string>
-      allColumns.forEach(col => {
+      allColumns.forEach((col) => {
         record[col.title] = rowRecord[col.key] ?? ''
       })
       return record
@@ -2820,14 +3055,16 @@ export default function Chessboard() {
   }, [viewRows, allColumns])
 
   return (
-    <div style={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
 
-      position: 'relative',
-      minHeight: 0
-    }}>
+        position: 'relative',
+        minHeight: 0,
+      }}
+    >
       <div className="filters" style={{ flexShrink: 0, paddingBottom: 16 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
           <Space align="center" size="middle">
@@ -2839,26 +3076,33 @@ export default function Chessboard() {
               allowClear
               value={filters.projectId}
               onChange={(value) => setFilters({ projectId: value })}
-              options={projects?.map((p) => ({
-                value: p.id,
-                label: <span style={{ fontWeight: 'bold' }}>{p.name}</span>
-              })) ?? []}
+              options={
+                projects?.map((p) => ({
+                  value: p.id,
+                  label: <span style={{ fontWeight: 'bold' }}>{p.name}</span>,
+                })) ?? []
+              }
               showSearch
               filterOption={(input, option) => {
                 const label = option?.label
-                return String(label ?? '').toLowerCase().includes(input.toLowerCase())
+                return String(label ?? '')
+                  .toLowerCase()
+                  .includes(input.toLowerCase())
               }}
             />
-            <Button
-              type="primary"
-              size="large"
-              onClick={handleApply} 
-              disabled={!filters.projectId}
-            >
+            <Button type="primary" size="large" onClick={handleApply} disabled={!filters.projectId}>
               Применить
             </Button>
-            <Badge 
-              count={[filters.blockId, filters.categoryId, filters.typeId, filters.tagId, filters.documentationId].filter(Boolean).length} 
+            <Badge
+              count={
+                [
+                  filters.blockId,
+                  filters.categoryId,
+                  filters.typeId,
+                  filters.tagId,
+                  filters.documentationId,
+                ].filter(Boolean).length
+              }
               size="small"
               style={{ marginRight: '8px' }}
             >
@@ -2867,19 +3111,22 @@ export default function Chessboard() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                      <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }} />
-                      {filtersExpanded ?
-                        <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} /> :
-                        <CaretDownFilled style={{ fontSize: '10px' }} />
-                    }
+                    <FilterOutlined
+                      style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }}
+                    />
+                    {filtersExpanded ? (
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} />
+                    ) : (
+                      <CaretDownFilled style={{ fontSize: '10px' }} />
+                    )}
                   </span>
                 }
                 title={filtersExpanded ? 'Скрыть фильтры' : 'Показать фильтры'}
-                style={{ 
+                style={{
                   padding: '4px 12px',
                   display: 'flex',
                   alignItems: 'center',
-                    borderColor: filtersExpanded ? '#a69ead' : undefined
+                  borderColor: filtersExpanded ? '#a69ead' : undefined,
                 }}
               >
                 Фильтры
@@ -2887,45 +3134,28 @@ export default function Chessboard() {
             </Badge>
           </Space>
           <Space>
-            {appliedFilters && !Object.keys(editingRows).length && mode === 'view' && !deleteMode && (
-              <Button
-                type="primary"
-                icon={<PlusOutlined />}
-                onClick={startAdd}
-              >
-                Добавить
-              </Button>
-            )}
+            {appliedFilters &&
+              !Object.keys(editingRows).length &&
+              mode === 'view' &&
+              !deleteMode && (
+                <Button type="primary" icon={<PlusOutlined />} onClick={startAdd}>
+                  Добавить
+                </Button>
+              )}
             {Object.keys(editingRows).length > 0 && (
               <>
-                <Button 
-                  type="primary"
-                  icon={<SaveOutlined />}
-                  onClick={handleUpdate}
-                >
+                <Button type="primary" icon={<SaveOutlined />} onClick={handleUpdate}>
                   Сохранить
                 </Button>
-                <Button
-                  onClick={handleCancelEdit}
-                >
-                  Отмена
-                </Button>
+                <Button onClick={handleCancelEdit}>Отмена</Button>
               </>
             )}
             {appliedFilters && mode === 'add' && (
               <>
-                <Button 
-                  type="primary"
-                  icon={<SaveOutlined />}
-                  onClick={handleSave}
-                >
+                <Button type="primary" icon={<SaveOutlined />} onClick={handleSave}>
                   Сохранить
                 </Button>
-                <Button
-                  onClick={handleCancel}
-                >
-                  Отменить
-                </Button>
+                <Button onClick={handleCancel}>Отменить</Button>
               </>
             )}
             {appliedFilters && !Object.keys(editingRows).length && mode === 'view' && (
@@ -2941,11 +3171,11 @@ export default function Chessboard() {
                   }
                 }}
               >
-                {deleteMode && selectedRows.size > 0 
-                  ? `Удалить (${selectedRows.size})` 
-                  : deleteMode 
-                  ? 'Выйти из режима' 
-                  : 'Удалить'}
+                {deleteMode && selectedRows.size > 0
+                  ? `Удалить (${selectedRows.size})`
+                  : deleteMode
+                    ? 'Выйти из режима'
+                    : 'Удалить'}
               </Button>
             )}
             {deleteMode && selectedRows.size === 0 && (
@@ -2978,139 +3208,151 @@ export default function Chessboard() {
             )}
           </Space>
         </div>
-        
+
         {filtersExpanded && (
           <Card size="small" style={{ marginTop: 12 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: '8px',
+              }}
+            >
               <Space wrap>
                 <Select
-                placeholder="Корпус"
-                style={{ width: 200 }}
-                value={filters.blockId}
-                onChange={(value) => setFilters((f) => ({ ...f, blockId: value }))}
-                options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
-                disabled={!filters.projectId}
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-              <Select
-                placeholder="Категория затрат"
-                style={{ width: 200 }}
-                value={filters.categoryId}
-                onChange={(value) =>
-                  setFilters((f) => ({ ...f, categoryId: value, typeId: undefined }))
-                }
-                popupMatchSelectWidth={false}
-                options={
-                  costCategories
-                    ?.sort((a, b) => {
-                      // Сортируем по номеру, если он есть
-                      if (a.number !== undefined && a.number !== null && 
-                          b.number !== undefined && b.number !== null) {
-                        // Числовое сравнение для правильной сортировки
-                        return Number(a.number) - Number(b.number)
-                      }
-                      return a.name.localeCompare(b.name)
-                    })
-                    .map((c) => ({
-                      value: String(c.id),
-                      label: c.name, // Отображаем только название без номера
+                  placeholder="Корпус"
+                  style={{ width: 200 }}
+                  value={filters.blockId}
+                  onChange={(value) => setFilters((f) => ({ ...f, blockId: value }))}
+                  options={blocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
+                  disabled={!filters.projectId}
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+                <Select
+                  placeholder="Категория затрат"
+                  style={{ width: 200 }}
+                  value={filters.categoryId}
+                  onChange={(value) =>
+                    setFilters((f) => ({ ...f, categoryId: value, typeId: undefined }))
+                  }
+                  popupMatchSelectWidth={false}
+                  options={
+                    costCategories
+                      ?.sort((a, b) => {
+                        // Сортируем по номеру, если он есть
+                        if (
+                          a.number !== undefined &&
+                          a.number !== null &&
+                          b.number !== undefined &&
+                          b.number !== null
+                        ) {
+                          // Числовое сравнение для правильной сортировки
+                          return Number(a.number) - Number(b.number)
+                        }
+                        return a.name.localeCompare(b.name)
+                      })
+                      .map((c) => ({
+                        value: String(c.id),
+                        label: c.name, // Отображаем только название без номера
+                      })) ?? []
+                  }
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+                <Select
+                  placeholder="Вид затрат"
+                  style={{ width: 200 }}
+                  value={filters.typeId}
+                  onChange={(value) => setFilters((f) => ({ ...f, typeId: value }))}
+                  options={
+                    costTypes
+                      ?.filter((t) => String(t.cost_category_id) === filters.categoryId)
+                      .map((t) => ({ value: String(t.id), label: t.name })) ?? []
+                  }
+                  disabled={!filters.categoryId}
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+                <Select
+                  placeholder="Раздел"
+                  style={{ width: 200 }}
+                  value={filters.tagId}
+                  onChange={(value) =>
+                    setFilters((f) => ({ ...f, tagId: value, documentationId: undefined }))
+                  }
+                  options={
+                    documentationTags?.map((tag) => ({
+                      value: String(tag.id),
+                      label: `${tag.tag_number || ''} ${tag.name}`.trim(),
                     })) ?? []
-                }
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-              <Select
-                placeholder="Вид затрат"
-                style={{ width: 200 }}
-                value={filters.typeId}
-                onChange={(value) => setFilters((f) => ({ ...f, typeId: value }))}
-                options={
-                  costTypes
-                    ?.filter((t) => String(t.cost_category_id) === filters.categoryId)
-                    .map((t) => ({ value: String(t.id), label: t.name })) ?? []
-                }
-                disabled={!filters.categoryId}
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-              <Select
-                placeholder="Раздел"
-                style={{ width: 200 }}
-                value={filters.tagId}
-                onChange={(value) => setFilters((f) => ({ ...f, tagId: value, documentationId: undefined }))}
-                options={
-                  documentationTags?.map((tag) => ({
-                    value: String(tag.id),
-                    label: `${tag.tag_number || ''} ${tag.name}`.trim()
-                  })) ?? []
-                }
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
-              <Select
-                placeholder="Шифр документа"
-                style={{ width: 200 }}
-                value={filters.documentationId}
-                onChange={(value) => setFilters((f) => ({ ...f, documentationId: value }))}
-                options={
-                  documentations
-                    ?.filter((doc: DocumentationRecord) => !filters.tagId || String(doc.tag_id) === filters.tagId)
-                    .map((doc: DocumentationRecord) => ({
-                      value: doc.id,
-                      label: doc.project_code
-                    })) ?? []
-                }
-                disabled={!filters.tagId}
-                allowClear
-                showSearch
-                filterOption={(input, option) => {
-                  const text = (option?.label ?? '').toString()
-                  return text.toLowerCase().includes(input.toLowerCase())
-                }}
-              />
+                  }
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
+                <Select
+                  placeholder="Шифр документа"
+                  style={{ width: 200 }}
+                  value={filters.documentationId}
+                  onChange={(value) => setFilters((f) => ({ ...f, documentationId: value }))}
+                  options={
+                    documentations
+                      ?.filter(
+                        (doc: DocumentationRecord) =>
+                          !filters.tagId || String(doc.tag_id) === filters.tagId,
+                      )
+                      .map((doc: DocumentationRecord) => ({
+                        value: doc.id,
+                        label: doc.project_code,
+                      })) ?? []
+                  }
+                  disabled={!filters.tagId}
+                  allowClear
+                  showSearch
+                  filterOption={(input, option) => {
+                    const text = (option?.label ?? '').toString()
+                    return text.toLowerCase().includes(input.toLowerCase())
+                  }}
+                />
               </Space>
-              <Button
-                icon={<SettingOutlined />}
-                onClick={() => setColumnsSettingsOpen(true)}
-              >
+              <Button icon={<SettingOutlined />} onClick={() => setColumnsSettingsOpen(true)}>
                 Настройка столбцов
               </Button>
             </div>
           </Card>
         )}
       </div>
-      
+
       {/* Таблица */}
       {appliedFilters && (
         <div className="table-host chessboard-table">
           {mode === 'add' ? (
             <Table<TableRow>
-
               dataSource={tableRows}
               columns={orderedAddColumns}
               pagination={false}
               rowKey="key"
               sticky
               scroll={{
-                x: 'max-content'
-
+                x: 'max-content',
               }}
               rowClassName={(record) => (record.color ? `row-${record.color}` : '')}
             />
@@ -3122,8 +3364,7 @@ export default function Chessboard() {
               rowKey="key"
               sticky
               scroll={{
-                x: 'max-content'
-
+                x: 'max-content',
               }}
               rowClassName={(record) => {
                 const color = editingRows[record.key]?.color ?? record.color
@@ -3131,7 +3372,6 @@ export default function Chessboard() {
               }}
             />
           )}
-
         </div>
       )}
       <Modal
@@ -3144,7 +3384,11 @@ export default function Chessboard() {
         footer={
           floorModalIsEdit
             ? undefined
-            : [<Button key="close" onClick={cancelFloorModal}>Закрыть</Button>]
+            : [
+                <Button key="close" onClick={cancelFloorModal}>
+                  Закрыть
+                </Button>,
+              ]
         }
       >
         <div style={{ marginBottom: 16 }}>
@@ -3200,26 +3444,20 @@ export default function Chessboard() {
             <p className="ant-upload-drag-icon">
               <InboxOutlined />
             </p>
-            <p className="ant-upload-text">
-              Перетащите файл или нажмите для выбора
-            </p>
+            <p className="ant-upload-text">Перетащите файл или нажмите для выбора</p>
           </Upload.Dragger>
           <Select
             placeholder="Проект"
             style={{ width: '100%' }}
             value={importState.projectId}
-            onChange={(value) =>
-              setImportState({ projectId: value })
-            }
+            onChange={(value) => setImportState({ projectId: value })}
             options={projects?.map((p) => ({ value: p.id, label: p.name })) ?? []}
           />
           <Select
             placeholder="Корпус"
             style={{ width: '100%' }}
             value={importState.blockId}
-            onChange={(value) =>
-              setImportState((s) => ({ ...s, blockId: value }))
-            }
+            onChange={(value) => setImportState((s) => ({ ...s, blockId: value }))}
             options={importBlocks?.map((b) => ({ value: b.id, label: b.name })) ?? []}
             disabled={!importState.projectId}
           />
@@ -3236,7 +3474,8 @@ export default function Chessboard() {
               }))
             }
             popupMatchSelectWidth={false}
-            options={costCategories
+            options={
+              costCategories
                 ?.sort((a, b) => {
                   // Сортируем по номеру, если он есть
                   if (a.number && b.number) {
@@ -3249,7 +3488,8 @@ export default function Chessboard() {
                 .map((c) => ({
                   value: String(c.id),
                   label: c.name, // Отображаем только название без номера
-                })) ?? []}
+                })) ?? []
+            }
           />
           <Select
             placeholder="Вид затрат"
@@ -3263,23 +3503,23 @@ export default function Chessboard() {
                 locationId: loc ? String(loc) : undefined,
               }))
             }}
-            options={costTypes
+            options={
+              costTypes
                 ?.filter((t) => String(t.cost_category_id) === importState.categoryId)
-                .map((t) => ({ value: String(t.id), label: t.name })) ?? []}
+                .map((t) => ({ value: String(t.id), label: t.name })) ?? []
+            }
             disabled={!importState.categoryId}
           />
           <Select
             placeholder="Локализация"
             style={{ width: '100%' }}
             value={importState.locationId ?? ''}
-            onChange={(value) =>
-              setImportState((s) => ({ ...s, locationId: value || undefined }))
-            }
+            onChange={(value) => setImportState((s) => ({ ...s, locationId: value || undefined }))}
             options={locations?.map((l) => ({ value: String(l.id), label: l.name })) ?? []}
           />
         </Space>
       </Modal>
-      
+
       <Drawer
         title="Настройка столбцов"
         placement="right"
@@ -3287,56 +3527,63 @@ export default function Chessboard() {
         open={columnsSettingsOpen}
         width={350}
       >
-        <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div
+          style={{
+            marginBottom: 16,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
           <Checkbox
-            checked={allColumns.every(col => columnVisibility[col.key] !== false)}
-            indeterminate={allColumns.some(col => columnVisibility[col.key]) && !allColumns.every(col => columnVisibility[col.key] !== false)}
+            checked={allColumns.every((col) => columnVisibility[col.key] !== false)}
+            indeterminate={
+              allColumns.some((col) => columnVisibility[col.key]) &&
+              !allColumns.every((col) => columnVisibility[col.key] !== false)
+            }
             onChange={(e) => selectAllColumns(e.target.checked)}
           >
             Выделить все
           </Checkbox>
-          <Button
-            type="link"
-            onClick={resetToDefaults}
-          >
+          <Button type="link" onClick={resetToDefaults}>
             По умолчанию
           </Button>
         </div>
         <List
-          dataSource={columnOrder.map(key => {
-            const col = allColumns.find(c => c.key === key)
-            return col ? { ...col, visible: columnVisibility[key] !== false } : null
-          }).filter(Boolean)}
-          renderItem={(item, index) => item && (
-            <List.Item
-              actions={[
-                <Button
-                  type="text"
-                  icon={<ArrowUpOutlined />}
-                  onClick={() => moveColumn(item.key, 'up')}
-                  disabled={index === 0}
-                  size="small"
-                />,
-                <Button
-                  type="text"
-                  icon={<ArrowDownOutlined />}
-                  onClick={() => moveColumn(item.key, 'down')}
-                  disabled={index === columnOrder.length - 1}
-                  size="small"
-                />
-              ]}
-            >
-              <Checkbox
-                checked={item.visible}
-                onChange={() => toggleColumnVisibility(item.key)}
+          dataSource={columnOrder
+            .map((key) => {
+              const col = allColumns.find((c) => c.key === key)
+              return col ? { ...col, visible: columnVisibility[key] !== false } : null
+            })
+            .filter(Boolean)}
+          renderItem={(item, index) =>
+            item && (
+              <List.Item
+                actions={[
+                  <Button
+                    type="text"
+                    icon={<ArrowUpOutlined />}
+                    onClick={() => moveColumn(item.key, 'up')}
+                    disabled={index === 0}
+                    size="small"
+                  />,
+                  <Button
+                    type="text"
+                    icon={<ArrowDownOutlined />}
+                    onClick={() => moveColumn(item.key, 'down')}
+                    disabled={index === columnOrder.length - 1}
+                    size="small"
+                  />,
+                ]}
               >
-                {item.title}
-              </Checkbox>
-            </List.Item>
-          )}
+                <Checkbox checked={item.visible} onChange={() => toggleColumnVisibility(item.key)}>
+                  {item.title}
+                </Checkbox>
+              </List.Item>
+            )
+          }
         />
       </Drawer>
     </div>
   )
 }
-

--- a/supabase.sql
+++ b/supabase.sql
@@ -40,10 +40,15 @@ create table if not exists estimate_items (
   unit_price numeric
 );
 
+create table if not exists materials (
+  uuid uuid primary key default gen_random_uuid(),
+  name text unique not null
+);
+
 create table if not exists chessboard (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references projects on delete cascade,
-  material text,
+  material uuid references materials(uuid),
   unit_id uuid references units on delete set null,
   cost_category_code text,
   color text,

--- a/supabase/migrations/create_materials_table_and_link_chessboard.sql
+++ b/supabase/migrations/create_materials_table_and_link_chessboard.sql
@@ -1,0 +1,11 @@
+create table if not exists public.materials (
+  uuid uuid primary key default gen_random_uuid(),
+  name text unique not null
+);
+
+-- очистить существующие значения, чтобы избежать ошибок приведения типов
+update public.chessboard set material = null;
+
+alter table if exists public.chessboard
+  alter column material type uuid using material::uuid,
+  add constraint chessboard_material_fkey foreign key (material) references public.materials (uuid);


### PR DESCRIPTION
## Summary
- add materials reference table and link chessboard rows by uuid
- suggest existing materials or create new ones when editing chessboard
- expose materials API for fetching and upserting names
- clear existing text values in chessboard.material before casting to uuid

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b35e048ff0832eb6d4c3a8b7bf2629