### PR TITLE
fix: handle missing supabase on documentation page

### DIFF
--- a/src/entities/documentation-tags/api/documentation-tags-api.ts
+++ b/src/entities/documentation-tags/api/documentation-tags-api.ts
@@ -7,7 +7,9 @@ import type {
 
 export const documentationTagsApi = {
   async getAll() {
-    if (!supabase) throw new Error('Supabase client not initialized')
+    if (!supabase) {
+      return []
+    }
 
     const { data, error } = await supabase
       .from('documentation_tags')
@@ -77,10 +79,7 @@ export const documentationTagsApi = {
   async delete(id: number) {
     if (!supabase) throw new Error('Supabase client not initialized')
 
-    const { error } = await supabase
-      .from('documentation_tags')
-      .delete()
-      .eq('id', id)
+    const { error } = await supabase.from('documentation_tags').delete().eq('id', id)
 
     if (error) {
       console.error('Failed to delete documentation tag:', error)

--- a/src/entities/documentation/api/documentation-api.ts
+++ b/src/entities/documentation/api/documentation-api.ts
@@ -64,7 +64,6 @@ export const documentationApi = {
 
     // TODO: Добавить колонку color в БД
 
-
     const { data, error } = await supabase.from('documentations').select().eq('id', id).single()
 
     if (error) {
@@ -76,7 +75,9 @@ export const documentationApi = {
   },
   // Получение всех записей документации с фильтрами
   async getDocumentation(filters?: DocumentationFilters) {
-    if (!supabase) throw new Error('Supabase client not initialized')
+    if (!supabase) {
+      return []
+    }
 
     // Если есть фильтр по проекту или блоку, сначала получаем документы через маппинг
     let documentationIds: string[] | null = null


### PR DESCRIPTION
## Summary
- avoid crashes when Supabase env missing on documentation page

## Testing
- `npm run lint`
- `npm run build`
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b44a73bb0c832eafeac830569e4960