### PR TITLE
fix: restore documentation page loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,15 +6,14 @@ import Dashboard from './pages/Dashboard'
 import Documents from './pages/Documents'
 import Chessboard from './pages/documents/Chessboard'
 import Vor from './pages/documents/Vor'
-import DocumentationDocs from './pages/Documentation'
 import References from './pages/References'
 import Units from './pages/references/Units'
-import DocumentationReference from './pages/references/Documentation'
 import CostCategories from './pages/references/CostCategories'
 import Projects from './pages/references/Projects'
 import Locations from './pages/references/Locations'
 import Rates from './pages/references/Rates'
 import Nomenclature from './pages/references/Nomenclature'
+import Documentation from './pages/documents/Documentation'
 import Admin from './pages/Admin'
 import DocumentationTags from './pages/admin/DocumentationTags'
 import Statuses from './pages/admin/Statuses'
@@ -223,6 +222,19 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
           ВОР
         </Link>
       </div>
+      <div
+        style={menuItemStyle}
+        onMouseEnter={(e) =>
+          (e.currentTarget.style.backgroundColor = isDark
+            ? 'rgba(255, 255, 255, 0.1)'
+            : 'rgba(0, 0, 0, 0.05)')
+        }
+        onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+      >
+        <Link to="/documents/documentation" style={linkStyle}>
+          Документация
+        </Link>
+      </div>
     </div>
   )
 
@@ -245,19 +257,6 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
       >
         <Link to="/references" style={linkStyle}>
           Единицы измерения
-        </Link>
-      </div>
-      <div
-        style={menuItemStyle}
-        onMouseEnter={(e) =>
-          (e.currentTarget.style.backgroundColor = isDark
-            ? 'rgba(255, 255, 255, 0.1)'
-            : 'rgba(0, 0, 0, 0.05)')
-        }
-        onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
-      >
-        <Link to="/references/documentation" style={linkStyle}>
-          Документация
         </Link>
       </div>
       <div
@@ -477,10 +476,6 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
         : [
             { key: 'units', label: <Link to="/references">Единицы измерения</Link> },
             {
-              key: 'documentation',
-              label: <Link to="/references/documentation">Документация</Link>,
-            },
-            {
               key: 'cost-categories',
               label: <Link to="/references/cost-categories">Категории затрат</Link>,
             },
@@ -694,29 +689,27 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
                     ? 'vor'
                     : location.pathname.startsWith('/documents/documentation')
                       ? 'docs'
-                      : location.pathname.startsWith('/references/documentation')
-                        ? 'documentation'
-                        : location.pathname.startsWith('/references/cost-categories')
-                          ? 'cost-categories'
-                          : location.pathname.startsWith('/references/projects')
-                            ? 'projects'
-                            : location.pathname.startsWith('/references/locations')
-                              ? 'locations'
-                              : location.pathname.startsWith('/references/rates')
-                                ? 'rates'
-                                : location.pathname.startsWith('/references/nomenclature')
-                                  ? 'nomenclature'
-                                  : location.pathname.startsWith('/references')
-                                    ? 'units'
-                                    : location.pathname.startsWith('/admin/documentation-tags')
-                                      ? 'documentation-tags'
-                                      : location.pathname.startsWith('/admin/statuses')
-                                        ? 'statuses'
-                                        : location.pathname.startsWith('/admin/disk')
-                                          ? 'disk'
-                                          : location.pathname.startsWith('/admin/portal-settings')
-                                            ? 'portal-settings'
-                                            : location.pathname,
+                      : location.pathname.startsWith('/references/cost-categories')
+                        ? 'cost-categories'
+                        : location.pathname.startsWith('/references/projects')
+                          ? 'projects'
+                          : location.pathname.startsWith('/references/locations')
+                            ? 'locations'
+                            : location.pathname.startsWith('/references/rates')
+                              ? 'rates'
+                              : location.pathname.startsWith('/references/nomenclature')
+                                ? 'nomenclature'
+                                : location.pathname.startsWith('/references')
+                                  ? 'units'
+                                  : location.pathname.startsWith('/admin/documentation-tags')
+                                    ? 'documentation-tags'
+                                    : location.pathname.startsWith('/admin/statuses')
+                                      ? 'statuses'
+                                      : location.pathname.startsWith('/admin/disk')
+                                        ? 'disk'
+                                        : location.pathname.startsWith('/admin/portal-settings')
+                                          ? 'portal-settings'
+                                          : location.pathname,
             ]}
             openKeys={openKeys}
             onOpenChange={setOpenKeys}
@@ -743,11 +736,10 @@ const App = ({ isDark, toggleTheme }: AppProps) => {
                 <Route path="/documents" element={<Documents />}>
                   <Route path="chessboard" element={<Chessboard />} />
                   <Route path="vor" element={<Vor />} />
-                  <Route path="documentation" element={<DocumentationDocs />} />
+                  <Route path="documentation" element={<Documentation />} />
                 </Route>
                 <Route path="/references" element={<References />}>
                   <Route index element={<Units />} />
-                  <Route path="documentation" element={<DocumentationReference />} />
                   <Route path="cost-categories" element={<CostCategories />} />
                   <Route path="projects" element={<Projects />} />
                   <Route path="locations" element={<Locations />} />

--- a/src/entities/documentation-tags/api/documentation-tags-api.ts
+++ b/src/entities/documentation-tags/api/documentation-tags-api.ts
@@ -7,7 +7,9 @@ import type {
 
 export const documentationTagsApi = {
   async getAll() {
-    if (!supabase) throw new Error('Supabase client not initialized')
+    if (!supabase) {
+      return []
+    }
 
     const { data, error } = await supabase
       .from('documentation_tags')
@@ -77,10 +79,7 @@ export const documentationTagsApi = {
   async delete(id: number) {
     if (!supabase) throw new Error('Supabase client not initialized')
 
-    const { error } = await supabase
-      .from('documentation_tags')
-      .delete()
-      .eq('id', id)
+    const { error } = await supabase.from('documentation_tags').delete().eq('id', id)
 
     if (error) {
       console.error('Failed to delete documentation tag:', error)

--- a/src/entities/documentation/api/documentation-api.ts
+++ b/src/entities/documentation/api/documentation-api.ts
@@ -64,7 +64,6 @@ export const documentationApi = {
 
     // TODO: Добавить колонку color в БД
 
-
     const { data, error } = await supabase.from('documentations').select().eq('id', id).single()
 
     if (error) {
@@ -76,7 +75,9 @@ export const documentationApi = {
   },
   // Получение всех записей документации с фильтрами
   async getDocumentation(filters?: DocumentationFilters) {
-    if (!supabase) throw new Error('Supabase client not initialized')
+    if (!supabase) {
+      return []
+    }
 
     // Если есть фильтр по проекту или блоку, сначала получаем документы через маппинг
     let documentationIds: string[] | null = null
@@ -113,7 +114,7 @@ export const documentationApi = {
           version_number,
           issue_date,
           file_url,
-          local_files,
+          file_paths:documentation_file_paths(file_path),
           status,
           created_at,
           updated_at
@@ -151,7 +152,21 @@ export const documentationApi = {
 
     // Преобразуем данные для отображения в таблице
     const tableData: DocumentationTableRow[] = (data || []).map((doc) => {
-      let versions = Array.isArray(doc.versions) ? doc.versions : []
+      let versions = Array.isArray(doc.versions)
+        ? ((doc.versions as any[]).map((v) => ({
+            ...v,
+            local_files: Array.isArray(v.file_paths)
+              ? v.file_paths.map((fp: { file_path: string }) => ({
+                  name: fp.file_path.split('/').pop() || '',
+                  path: fp.file_path,
+                  size: 0,
+                  type: '',
+                  extension: fp.file_path.split('.').pop() || '',
+                  uploadedAt: '',
+                }))
+              : [],
+          })) as DocumentationVersion[])
+        : []
 
       // Фильтруем по статусу если нужно
       if (filters?.status) {
@@ -274,7 +289,6 @@ export const documentationApi = {
     versionNumber: number,
     issueDate?: string,
     fileUrl?: string,
-    filePath?: string,
     status: DocumentationVersion['status'] = 'not_filled',
   ) {
     if (!supabase) throw new Error('Supabase client not initialized')
@@ -284,7 +298,6 @@ export const documentationApi = {
       version_number: versionNumber,
       issue_date: issueDate || null,
       file_url: fileUrl || null,
-      file_path: filePath || null,
       status,
     }
 
@@ -309,7 +322,6 @@ export const documentationApi = {
     versionNumber: number,
     issueDate?: string,
     fileUrl?: string,
-    filePath?: string,
     status: DocumentationVersion['status'] = 'not_filled',
   ) {
     if (!supabase) throw new Error('Supabase client not initialized')
@@ -327,7 +339,6 @@ export const documentationApi = {
       version_number: versionNumber,
       issue_date: issueDate || null,
       file_url: fileUrl || null,
-      file_path: filePath || null,
       status,
     }
 
@@ -338,7 +349,6 @@ export const documentationApi = {
         .update({
           issue_date: issueDate || null,
           file_url: fileUrl || null,
-          file_path: filePath || null,
           status,
         })
         .eq('id', existingVersion.id)
@@ -390,30 +400,40 @@ export const documentationApi = {
   // Обновление локальных файлов версии
   async updateVersionLocalFiles(versionId: string, localFiles: LocalFile[]) {
     if (!supabase) throw new Error('Supabase client not initialized')
+    const { error: deleteError } = await supabase
+      .from('documentation_file_paths')
+      .delete()
+      .eq('version_id', versionId)
 
-    const { data, error } = await supabase
-      .from('documentation_versions')
-      .update({
-        local_files: localFiles,
-      })
-      .eq('id', versionId)
-      .select()
-      .single()
+    if (deleteError) {
+      console.error('Failed to update version local files:', deleteError)
+      throw deleteError
+    }
 
-    if (!error) {
-      await supabase.from('documentation_file_paths').delete().eq('version_id', versionId)
+    if (localFiles.length) {
       const rows = localFiles.map((f) => ({ version_id: versionId, file_path: f.path }))
-      if (rows.length) {
-        await supabase.from('documentation_file_paths').insert(rows)
+      const { error: insertError } = await supabase.from('documentation_file_paths').insert(rows)
+
+      if (insertError) {
+        console.error('Failed to update version local files:', insertError)
+        throw insertError
       }
     }
 
-    if (error) {
-      console.error('Failed to update version local files:', error)
-      throw error
+    const { data, error: fetchError } = await supabase
+      .from('documentation_versions')
+      .select(
+        'id, documentation_id, version_number, issue_date, file_url, status, created_at, updated_at',
+      )
+      .eq('id', versionId)
+      .single()
+
+    if (fetchError) {
+      console.error('Failed to fetch version after updating files:', fetchError)
+      throw fetchError
     }
 
-    return data as DocumentationVersion
+    return { ...(data as DocumentationVersion), local_files: localFiles }
   },
 
   // Проверка конфликтов перед импортом
@@ -635,7 +655,6 @@ export const documentationApi = {
     versionNumber?: number
     issueDate?: string
     fileUrl?: string
-    filePath?: string
     status?: DocumentationVersion['status']
     comment?: string
     forceOverwrite?: boolean // Флаг для принудительной перезаписи при конфликте
@@ -663,15 +682,14 @@ export const documentationApi = {
             data.versionNumber,
             data.issueDate,
             data.fileUrl,
-            data.filePath,
             data.status || 'not_filled',
           )
+        } else {
           version = await this.createVersion(
             doc.id,
             data.versionNumber,
             data.issueDate,
             data.fileUrl,
-            data.filePath,
             data.status || 'not_filled',
           )
         }

--- a/src/entities/documentation/types.ts
+++ b/src/entities/documentation/types.ts
@@ -1,9 +1,9 @@
 export interface Documentation {
   id: string // UUID
   code: string
-  stage?: 'П' | 'Р' | null   // Стадия проектирования
+  stage?: 'П' | 'Р' | null // Стадия проектирования
   tag_id: number | null
-  color?: string | null      // Цвет строки
+  color?: string | null // Цвет строки
   created_at: string
   updated_at: string
   // Relations
@@ -33,7 +33,6 @@ export interface DocumentationVersion {
   version_number: number
   issue_date: string | null
   file_url: string | null
-  file_path: string | null
   local_files: LocalFile[]
   status: 'filled_recalc' | 'filled_spec' | 'not_filled' | 'vor_created'
   created_at: string
@@ -60,14 +59,14 @@ export interface DocumentationTag {
 }
 
 export interface Project {
-  id: string  // UUID
+  id: string // UUID
   name: string
   code?: string
   address?: string
 }
 
 export interface Block {
-  id: string  // UUID
+  id: string // UUID
   name: string
   bottom_underground_floor?: number
   top_ground_floor?: number
@@ -76,7 +75,7 @@ export interface Block {
 // Import types
 export interface DocumentationImportRow {
   tag: string // Раздел
-  code: string // Шифр проекта  
+  code: string // Шифр проекта
   version_number: number // Номер версии
   issue_date?: string // Дата выдачи версии
   file_url?: string // Ссылка на документ
@@ -89,7 +88,7 @@ export interface DocumentationImportRow {
 export interface DocumentationTableRow {
   id: string // Уникальный ключ для React
   documentation_id: string // UUID
-  stage?: 'П' | 'Р' | null   // Стадия проектирования
+  stage?: 'П' | 'Р' | null // Стадия проектирования
   tag_id: number | null // ID тега для фильтрации
   tag_name: string
   tag_number: number
@@ -100,8 +99,8 @@ export interface DocumentationTableRow {
   selected_version?: number // Выбранная версия для отображения
   selected_version_id?: string // ID выбранной версии (для случаев когда все версии имеют одинаковый номер)
   comments: string
-  project_id: string | null  // UUID
-  block_id: string | null    // UUID
+  project_id: string | null // UUID
+  block_id: string | null // UUID
   color?: string // Цвет строки
   isNew?: boolean // Признак новой записи
   // Поля для новых версий
@@ -113,10 +112,10 @@ export interface DocumentationTableRow {
 
 // Filter types
 export interface DocumentationFilters {
-  project_id?: string  // UUID
+  project_id?: string // UUID
   tag_id?: number
-  block_id?: string     // UUID
-  stage?: 'П' | 'Р'     // Стадия документа
+  block_id?: string // UUID
+  stage?: 'П' | 'Р' // Стадия документа
   status?: string
   show_latest_only?: boolean
 }

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -1,5 +1,0 @@
-import DataTable from '../components/DataTable';
-
-export default function Documentation() {
-  return <DataTable table="blueprints" />;
-}

--- a/src/pages/documents/Documentation.tsx
+++ b/src/pages/documents/Documentation.tsx
@@ -101,7 +101,6 @@ const getColumnSettings = (): DocumentationColumnSettings => {
   }
 }
 
-
 export default function Documentation() {
   const { message } = App.useApp()
   const { scale } = useScale()
@@ -124,11 +123,13 @@ export default function Documentation() {
   const [pendingImportData, setPendingImportData] = useState<DocumentationImportRow[]>([])
   const [resolvingConflicts, setResolvingConflicts] = useState(false)
   const [importSelectedProjectId, setImportSelectedProjectId] = useState<string | null>(null)
-  const [fileDuplicates, setFileDuplicates] = useState<Array<{
-    key: string
-    rows: DocumentationImportRow[]
-    indices: number[]
-  }>>([])
+  const [fileDuplicates, setFileDuplicates] = useState<
+    Array<{
+      key: string
+      rows: DocumentationImportRow[]
+      indices: number[]
+    }>
+  >([])
   const [duplicateDialogVisible, setDuplicateDialogVisible] = useState(false)
   const [selectedDuplicates, setSelectedDuplicates] = useState<Map<string, number>>(new Map())
   const [deleteMode, setDeleteMode] = useState(false)
@@ -138,57 +139,66 @@ export default function Documentation() {
     return saved ? parseInt(saved) : 100
   })
   const [editingRows, setEditingRows] = useState<Record<string, DocumentationTableRow>>({}) // Для множественного редактирования
-  
+
   // Состояния для управления столбцами
   const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({})
   const [columnOrder, setColumnOrder] = useState<string[]>([])
-  
+
   // Диагностика двойного скролла
 
   // Функции управления столбцами
   const toggleColumnVisibility = useCallback((key: string) => {
-    setColumnVisibility(prev => ({
+    setColumnVisibility((prev) => ({
       ...prev,
-      [key]: prev[key] === false ? true : false
+      [key]: prev[key] === false ? true : false,
     }))
   }, [])
-  
-  const selectAllColumns = useCallback((select: boolean, allColumnsData: Array<{key: string, title: string}>) => {
-    const newVisibility: Record<string, boolean> = {}
-    allColumnsData.forEach(col => {
-      newVisibility[col.key] = select
-    })
-    setColumnVisibility(newVisibility)
-  }, [])
-  
-  const resetToDefaults = useCallback((allColumnsData: Array<{key: string, title: string}>) => {
+
+  const selectAllColumns = useCallback(
+    (select: boolean, allColumnsData: Array<{ key: string; title: string }>) => {
+      const newVisibility: Record<string, boolean> = {}
+      allColumnsData.forEach((col) => {
+        newVisibility[col.key] = select
+      })
+      setColumnVisibility(newVisibility)
+    },
+    [],
+  )
+
+  const resetToDefaults = useCallback((allColumnsData: Array<{ key: string; title: string }>) => {
     // Сброс видимости - все столбцы видимы
     const defaultVisibility: Record<string, boolean> = {}
-    allColumnsData.forEach(col => {
+    allColumnsData.forEach((col) => {
       defaultVisibility[col.key] = true
     })
     setColumnVisibility(defaultVisibility)
-    
+
     // Сброс порядка - исходный порядок
-    setColumnOrder(allColumnsData.map(c => c.key))
-    
+    setColumnOrder(allColumnsData.map((c) => c.key))
+
     // Очистка localStorage
     localStorage.removeItem('documentation-column-visibility')
     localStorage.removeItem('documentation-column-order')
   }, [])
 
   const moveColumn = useCallback((key: string, direction: 'up' | 'down') => {
-    setColumnOrder(prev => {
+    setColumnOrder((prev) => {
       const currentIndex = prev.indexOf(key)
       if (currentIndex === -1) return prev
-      
+
       const newOrder = [...prev]
       if (direction === 'up' && currentIndex > 0) {
-        [newOrder[currentIndex], newOrder[currentIndex - 1]] = [newOrder[currentIndex - 1], newOrder[currentIndex]]
+        ;[newOrder[currentIndex], newOrder[currentIndex - 1]] = [
+          newOrder[currentIndex - 1],
+          newOrder[currentIndex],
+        ]
       } else if (direction === 'down' && currentIndex < prev.length - 1) {
-        [newOrder[currentIndex], newOrder[currentIndex + 1]] = [newOrder[currentIndex + 1], newOrder[currentIndex]]
+        ;[newOrder[currentIndex], newOrder[currentIndex + 1]] = [
+          newOrder[currentIndex + 1],
+          newOrder[currentIndex],
+        ]
       }
-      
+
       return newOrder
     })
   }, [])
@@ -224,17 +234,17 @@ export default function Documentation() {
         .from('projects_blocks')
         .select('block_id')
         .eq('project_id', filters.project_id)
-      
+
       if (!projectBlocks || projectBlocks.length === 0) return []
-      
+
       // Затем получаем сами блоки
-      const blockIds = projectBlocks.map(pb => pb.block_id)
+      const blockIds = projectBlocks.map((pb) => pb.block_id)
       const { data: blocksData } = await supabase
         .from('blocks')
         .select('*')
         .in('id', blockIds)
         .order('name')
-      
+
       return blocksData || []
     },
     enabled: !!filters.project_id,
@@ -250,17 +260,17 @@ export default function Documentation() {
         .from('projects_blocks')
         .select('block_id')
         .eq('project_id', importSelectedProjectId)
-      
+
       if (!projectBlocks || projectBlocks.length === 0) return []
-      
+
       // Затем получаем сами блоки
-      const blockIds = projectBlocks.map(pb => pb.block_id)
+      const blockIds = projectBlocks.map((pb) => pb.block_id)
       const { data: blocksData } = await supabase
         .from('blocks')
         .select('*')
         .in('id', blockIds)
         .order('name')
-      
+
       return blocksData || []
     },
     enabled: !!importSelectedProjectId,
@@ -268,7 +278,7 @@ export default function Documentation() {
 
   // Копирование строки
   const handleCopyRow = useCallback((record: DocumentationTableRow) => {
-      const newRow = {
+    const newRow = {
       ...record,
       id: `new-${Date.now()}`,
       documentation_id: '', // Пустой UUID для новых записей
@@ -277,19 +287,22 @@ export default function Documentation() {
       project_name: record.project_name,
       isNew: true,
       // Поля для новой версии - берем из последней версии или значения по умолчанию
-      new_version_number: record.versions.length > 0 ? record.versions[record.versions.length - 1].version_number + 1 : 1,
+      new_version_number:
+        record.versions.length > 0
+          ? record.versions[record.versions.length - 1].version_number + 1
+          : 1,
       new_issue_date: '',
       new_file_url: '',
       new_status: 'not_filled' as DocumentationVersion['status'],
     }
-    setNewRows(prev => [...prev, newRow])
+    setNewRows((prev) => [...prev, newRow])
     setAddMode(true)
   }, [])
 
   // Добавление строки после текущей
   const handleAddRowAfter = useCallback((record: DocumentationTableRow) => {
-    setNewRows(prev => {
-      const index = prev.findIndex(r => r.id === record.id)
+    setNewRows((prev) => {
+      const index = prev.findIndex((r) => r.id === record.id)
       const newRow: DocumentationTableRow = {
         id: `new-${Date.now()}`,
         documentation_id: '', // Пустой UUID для новых записей
@@ -320,8 +333,8 @@ export default function Documentation() {
 
   // Удаление новой строки
   const handleDeleteNew = useCallback((record: DocumentationTableRow) => {
-    setNewRows(prev => {
-      const updated = prev.filter(r => r.id !== record.id)
+    setNewRows((prev) => {
+      const updated = prev.filter((r) => r.id !== record.id)
       if (updated.length === 0) {
         setAddMode(false)
       }
@@ -330,44 +343,49 @@ export default function Documentation() {
   }, [])
 
   // Удаление записи
-  const handleDelete = useCallback(async (record: DocumentationTableRow) => {
-    if (record.documentation_id) {
-      try {
-        await documentationApi.deleteDocumentation(record.documentation_id)
-        message.success('Запись успешно удалена')
-        queryClient.invalidateQueries({ queryKey: ['documentation'] })
-      } catch (error) {
-        console.error('Delete error:', error)
-        message.error('Ошибка при удалении записи')
+  const handleDelete = useCallback(
+    async (record: DocumentationTableRow) => {
+      if (record.documentation_id) {
+        try {
+          await documentationApi.deleteDocumentation(record.documentation_id)
+          message.success('Запись успешно удалена')
+          queryClient.invalidateQueries({ queryKey: ['documentation'] })
+        } catch (error) {
+          console.error('Delete error:', error)
+          message.error('Ошибка при удалении записи')
+        }
       }
-    }
-  }, [queryClient, message])
+    },
+    [queryClient, message],
+  )
 
   // Колонки таблицы
   const columns = useMemo(() => {
     // Чекбокс колонка для режима удаления
-    const checkboxColumn = deleteMode ? {
-      title: '',
-      dataIndex: 'checkbox',
-      key: 'checkbox',
-      width: 50,
-      fixed: 'left' as const,
-      render: (_: unknown, record: DocumentationTableRow) => (
-        <Checkbox
-          checked={selectedRowsForDelete.has(record.id)}
-          onChange={() => {
-            const newSelected = new Set(selectedRowsForDelete)
-            if (newSelected.has(record.id)) {
-              newSelected.delete(record.id)
-            } else {
-              newSelected.add(record.id)
-            }
-            setSelectedRowsForDelete(newSelected)
-          }}
-        />
-      ),
-      visible: true,
-    } : null
+    const checkboxColumn = deleteMode
+      ? {
+          title: '',
+          dataIndex: 'checkbox',
+          key: 'checkbox',
+          width: 50,
+          fixed: 'left' as const,
+          render: (_: unknown, record: DocumentationTableRow) => (
+            <Checkbox
+              checked={selectedRowsForDelete.has(record.id)}
+              onChange={() => {
+                const newSelected = new Set(selectedRowsForDelete)
+                if (newSelected.has(record.id)) {
+                  newSelected.delete(record.id)
+                } else {
+                  newSelected.add(record.id)
+                }
+                setSelectedRowsForDelete(newSelected)
+              }}
+            />
+          ),
+          visible: true,
+        }
+      : null
 
     const allColumns: Array<ColumnsType<DocumentationTableRow>[number] & { visible?: boolean }> = [
       // Колонка цвета - временно скрыта до добавления колонки в БД
@@ -404,10 +422,8 @@ export default function Documentation() {
                 style={{ width: '100%' }}
                 value={record.stage || 'П'}
                 onChange={(value) => {
-                  const updated = newRows.map(r => 
-                    r.id === record.id 
-                      ? { ...r, stage: value }
-                      : r
+                  const updated = newRows.map((r) =>
+                    r.id === record.id ? { ...r, stage: value } : r,
                   )
                   setNewRows(updated)
                 }}
@@ -428,7 +444,7 @@ export default function Documentation() {
         key: 'tag',
         width: 100,
         sorter: (a, b) => a.tag_name.localeCompare(b.tag_name),
-        filters: tags.map(t => ({ text: t.name, value: t.name })),
+        filters: tags.map((t) => ({ text: t.name, value: t.name })),
         onFilter: (value, record) => record.tag_name === value,
         visible: columnSettings.visible.tag,
         render: (text, record: DocumentationTableRow) => {
@@ -439,15 +455,15 @@ export default function Documentation() {
                 placeholder="Выберите раздел"
                 value={text}
                 onChange={(value) => {
-                  const tag = tags.find(t => t.name === value)
-                  const updated = newRows.map(r => 
-                    r.id === record.id 
+                  const tag = tags.find((t) => t.name === value)
+                  const updated = newRows.map((r) =>
+                    r.id === record.id
                       ? { ...r, tag_name: value, tag_number: tag?.tag_number || 0 }
-                      : r
+                      : r,
                   )
                   setNewRows(updated)
                 }}
-                options={tags.map(t => ({ label: t.name, value: t.name }))}
+                options={tags.map((t) => ({ label: t.name, value: t.name }))}
               />
             )
           }
@@ -458,17 +474,17 @@ export default function Documentation() {
                 style={{ width: '100%' }}
                 value={editedRow.tag_name}
                 onChange={(value) => {
-                  const tag = tags.find(t => t.name === value)
-                  setEditingRows(prev => ({
+                  const tag = tags.find((t) => t.name === value)
+                  setEditingRows((prev) => ({
                     ...prev,
                     [record.id]: {
                       ...editedRow,
                       tag_name: value,
-                      tag_number: tag?.tag_number || 0
-                    }
+                      tag_number: tag?.tag_number || 0,
+                    },
                   }))
                 }}
-                options={tags.map(t => ({ label: t.name, value: t.name }))}
+                options={tags.map((t) => ({ label: t.name, value: t.name }))}
               />
             )
           }
@@ -486,7 +502,7 @@ export default function Documentation() {
             <Input
               placeholder="Поиск по шифру"
               value={selectedKeys[0]}
-              onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+              onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
               onPressEnter={() => confirm()}
               style={{ marginBottom: 8, display: 'block' }}
             />
@@ -500,7 +516,11 @@ export default function Documentation() {
               >
                 Поиск
               </Button>
-              <Button onClick={() => clearFilters && clearFilters()} size="small" style={{ width: 90 }}>
+              <Button
+                onClick={() => clearFilters && clearFilters()}
+                size="small"
+                style={{ width: 90 }}
+              >
                 Сброс
               </Button>
             </Space>
@@ -521,19 +541,17 @@ export default function Documentation() {
                 value={record.isNew ? text : editedRow.project_code}
                 onChange={(e) => {
                   if (record.isNew) {
-                    const updated = newRows.map(r => 
-                      r.id === record.id 
-                        ? { ...r, project_code: e.target.value }
-                        : r
+                    const updated = newRows.map((r) =>
+                      r.id === record.id ? { ...r, project_code: e.target.value } : r,
                     )
                     setNewRows(updated)
                   } else {
-                    setEditingRows(prev => ({
+                    setEditingRows((prev) => ({
                       ...prev,
                       [record.id]: {
                         ...editedRow,
-                        project_code: e.target.value
-                      }
+                        project_code: e.target.value,
+                      },
                     }))
                   }
                 }}
@@ -562,10 +580,10 @@ export default function Documentation() {
                 size="small"
                 value={record.new_version_number}
                 onChange={(e) => {
-                  const updated = newRows.map(r => 
-                    r.id === record.id 
+                  const updated = newRows.map((r) =>
+                    r.id === record.id
                       ? { ...r, new_version_number: parseInt(e.target.value) || 1 }
-                      : r
+                      : r,
                   )
                   setNewRows(updated)
                 }}
@@ -573,27 +591,28 @@ export default function Documentation() {
               />
             )
           }
-          
+
           if (record.versions.length === 0) {
             return '-'
           }
-          
-          const currentSelectedVersion = selectedVersions[record.id] || 
-            record.selected_version || 
+
+          const currentSelectedVersion =
+            selectedVersions[record.id] ||
+            record.selected_version ||
             record.versions[record.versions.length - 1]?.version_number
-          
+
           return (
             <Select
               size="small"
               value={currentSelectedVersion}
               onChange={(value) => {
-                setSelectedVersions(prev => ({
+                setSelectedVersions((prev) => ({
                   ...prev,
-                  [record.id]: value
+                  [record.id]: value,
                 }))
               }}
               style={{ width: '100%' }}
-              options={record.versions.map(v => ({
+              options={record.versions.map((v) => ({
                 label: v.version_number.toString(),
                 value: v.version_number,
               }))}
@@ -607,8 +626,14 @@ export default function Documentation() {
         key: 'issue_date',
         width: 100,
         sorter: (a, b) => {
-          const aDate = a.versions.find(v => v.version_number === (a.selected_version || a.versions[0]?.version_number))?.issue_date || ''
-          const bDate = b.versions.find(v => v.version_number === (b.selected_version || b.versions[0]?.version_number))?.issue_date || ''
+          const aDate =
+            a.versions.find(
+              (v) => v.version_number === (a.selected_version || a.versions[0]?.version_number),
+            )?.issue_date || ''
+          const bDate =
+            b.versions.find(
+              (v) => v.version_number === (b.selected_version || b.versions[0]?.version_number),
+            )?.issue_date || ''
           return aDate.localeCompare(bDate)
         },
         render: (_, record: DocumentationTableRow) => {
@@ -619,10 +644,8 @@ export default function Documentation() {
                 size="small"
                 value={record.new_issue_date}
                 onChange={(e) => {
-                  const updated = newRows.map(r => 
-                    r.id === record.id 
-                      ? { ...r, new_issue_date: e.target.value }
-                      : r
+                  const updated = newRows.map((r) =>
+                    r.id === record.id ? { ...r, new_issue_date: e.target.value } : r,
                   )
                   setNewRows(updated)
                 }}
@@ -632,28 +655,29 @@ export default function Documentation() {
           // Показываем дату выбранной версии
           // Используем ID версии если все версии имеют одинаковый номер
           let selectedVersion: DocumentationVersion | undefined
-          
-          if (record.selected_version_id && record.versions.every(v => v.version_number === 1)) {
+
+          if (record.selected_version_id && record.versions.every((v) => v.version_number === 1)) {
             // Все версии имеют номер 1, используем ID
-            selectedVersion = record.versions.find(v => v.id === record.selected_version_id)
+            selectedVersion = record.versions.find((v) => v.id === record.selected_version_id)
           } else {
             // Обычный случай - используем номер версии
-            const versionNumber = selectedVersions[record.id] || 
-              record.selected_version || 
+            const versionNumber =
+              selectedVersions[record.id] ||
+              record.selected_version ||
               record.versions[record.versions.length - 1]?.version_number
-            selectedVersion = record.versions.find(v => v.version_number === versionNumber)
+            selectedVersion = record.versions.find((v) => v.version_number === versionNumber)
           }
-          
+
           // Debug для первых записей
           if (record.project_code && record.project_code.startsWith('СТ26/01-14-АР')) {
             console.log('Date render debug:', {
               code: record.project_code,
               selectedVersionId: record.selected_version_id,
               selectedVersion,
-              date: selectedVersion?.issue_date
+              date: selectedVersion?.issue_date,
             })
           }
-          
+
           return formatDate(selectedVersion?.issue_date)
         },
         visible: columnVisibility.issue_date !== false,
@@ -667,7 +691,10 @@ export default function Documentation() {
           { text: 'Нет файла', value: 'no_file' },
         ],
         onFilter: (value, record) => {
-          const selectedVersion = record.versions.find(v => v.version_number === (record.selected_version || record.versions[0]?.version_number))
+          const selectedVersion = record.versions.find(
+            (v) =>
+              v.version_number === (record.selected_version || record.versions[0]?.version_number),
+          )
           const hasFile = !!selectedVersion?.file_url
           return value === 'has_file' ? hasFile : !hasFile
         },
@@ -678,10 +705,8 @@ export default function Documentation() {
                 size="small"
                 value={record.new_file_url || ''}
                 onChange={(e) => {
-                  const updated = newRows.map(r => 
-                    r.id === record.id 
-                      ? { ...r, new_file_url: e.target.value }
-                      : r
+                  const updated = newRows.map((r) =>
+                    r.id === record.id ? { ...r, new_file_url: e.target.value } : r,
                   )
                   setNewRows(updated)
                 }}
@@ -689,24 +714,25 @@ export default function Documentation() {
               />
             )
           }
-          
+
           // Показываем файлы выбранной версии
           // Используем ID версии если все версии имеют одинаковый номер
           let selectedVersion: DocumentationVersion | undefined
-          
-          if (record.selected_version_id && record.versions.every(v => v.version_number === 1)) {
+
+          if (record.selected_version_id && record.versions.every((v) => v.version_number === 1)) {
             // Все версии имеют номер 1, используем ID
-            selectedVersion = record.versions.find(v => v.id === record.selected_version_id)
+            selectedVersion = record.versions.find((v) => v.id === record.selected_version_id)
           } else {
             // Обычный случай - используем номер версии
-            const versionNumber = selectedVersions[record.id] || 
-              record.selected_version || 
+            const versionNumber =
+              selectedVersions[record.id] ||
+              record.selected_version ||
               record.versions[record.versions.length - 1]?.version_number
-            selectedVersion = record.versions.find(v => v.version_number === versionNumber)
+            selectedVersion = record.versions.find((v) => v.version_number === versionNumber)
           }
 
           return (
-              <FileUpload
+            <FileUpload
               files={selectedVersion?.local_files || []}
               onChange={async (files) => {
                 if (selectedVersion) {
@@ -720,11 +746,9 @@ export default function Documentation() {
                 }
               }}
               disabled={false}
-
               projectName={record.project_name}
               sectionName={record.tag_name}
               documentationCode={record.project_code}
-
               onlineFileUrl={selectedVersion?.file_url || undefined}
             />
           )
@@ -743,10 +767,8 @@ export default function Documentation() {
             autoSize={{ minRows: 1, maxRows: 2 }}
             onChange={(e) => {
               if (record.isNew) {
-                const updated = newRows.map(r => 
-                  r.id === record.id 
-                    ? { ...r, comments: e.target.value }
-                    : r
+                const updated = newRows.map((r) =>
+                  r.id === record.id ? { ...r, comments: e.target.value } : r,
                 )
                 setNewRows(updated)
               }
@@ -790,7 +812,7 @@ export default function Documentation() {
               </Space>
             )
           }
-          
+
           if (editingKey === record.id || editingRows[record.id]) {
             return (
               <Space size="small">
@@ -805,7 +827,7 @@ export default function Documentation() {
                       try {
                         // TODO: Добавить сохранение через API
                         message.success('Запись обновлена')
-                        setEditingRows(prev => {
+                        setEditingRows((prev) => {
                           const newRows = { ...prev }
                           delete newRows[record.id]
                           return newRows
@@ -824,7 +846,7 @@ export default function Documentation() {
                   danger
                   icon={<CloseOutlined />}
                   onClick={() => {
-                    setEditingRows(prev => {
+                    setEditingRows((prev) => {
                       const newRows = { ...prev }
                       delete newRows[record.id]
                       return newRows
@@ -851,9 +873,9 @@ export default function Documentation() {
                 icon={<EditOutlined />}
                 onClick={() => {
                   setEditingKey(record.id)
-                  setEditingRows(prev => ({
+                  setEditingRows((prev) => ({
                     ...prev,
-                    [record.id]: { ...record }
+                    [record.id]: { ...record },
                   }))
                 }}
               />
@@ -864,13 +886,7 @@ export default function Documentation() {
                 okText="Да"
                 cancelText="Отмена"
               >
-                <Button
-                  type="text"
-                  size="small"
-                  danger
-                  icon={<DeleteOutlined />}
-                  title="Удалить"
-                />
+                <Button type="text" size="small" danger icon={<DeleteOutlined />} title="Удалить" />
               </Popconfirm>
             </Space>
           )
@@ -879,31 +895,51 @@ export default function Documentation() {
     ]
 
     // Фильтруем и упорядочиваем столбцы согласно настройкам
-    const orderedColumns = columnOrder.length > 0 ? 
-      columnOrder
-        .filter(key => {
-          // Служебные столбцы не управляются порядком
-          if (key === 'checkbox' || key === 'actions') return false
-          return columnVisibility[key] !== false
-        })
-        .map(key => allColumns.find(col => col.key === key))
-        .filter(Boolean) 
-      : allColumns.filter(col => col.visible !== false)
+    const orderedColumns =
+      columnOrder.length > 0
+        ? columnOrder
+            .filter((key) => {
+              // Служебные столбцы не управляются порядком
+              if (key === 'checkbox' || key === 'actions') return false
+              return columnVisibility[key] !== false
+            })
+            .map((key) => allColumns.find((col) => col.key === key))
+            .filter(Boolean)
+        : allColumns.filter((col) => col.visible !== false)
 
     // Добавляем служебные столбцы в конце
-    const actionColumn = allColumns.find(col => col.key === 'actions')
+    const actionColumn = allColumns.find((col) => col.key === 'actions')
     const visibleColumns = actionColumn ? [...orderedColumns, actionColumn] : orderedColumns
-    
+
     // Добавляем checkbox колонку в начало если включен режим удаления
     const finalColumns = checkboxColumn ? [checkboxColumn, ...visibleColumns] : visibleColumns
-    
+
     // Удаляем свойство visible перед возвратом
-    return (finalColumns as Array<ColumnsType<DocumentationTableRow>[number] & { visible?: boolean }>).map((col) => {
+    return (
+      finalColumns as Array<ColumnsType<DocumentationTableRow>[number] & { visible?: boolean }>
+    ).map((col) => {
       const { visible, ...rest } = col
       void visible
       return rest
     }) as ColumnsType<DocumentationTableRow>
-  }, [columnSettings, newRows, editingKey, editingRows, tags, selectedVersions, handleAddRowAfter, handleCopyRow, handleDeleteNew, handleDelete, deleteMode, selectedRowsForDelete, message, queryClient, columnVisibility, columnOrder])
+  }, [
+    columnSettings,
+    newRows,
+    editingKey,
+    editingRows,
+    tags,
+    selectedVersions,
+    handleAddRowAfter,
+    handleCopyRow,
+    handleDeleteNew,
+    handleDelete,
+    deleteMode,
+    selectedRowsForDelete,
+    message,
+    queryClient,
+    columnVisibility,
+    columnOrder,
+  ])
 
   // Получаем все столбцы для управления настройками
   const allColumnsForSettings = useMemo(() => {
@@ -926,13 +962,13 @@ export default function Documentation() {
   useEffect(() => {
     const savedVisibility = localStorage.getItem('documentation-column-visibility')
     const savedOrder = localStorage.getItem('documentation-column-order')
-    
+
     if (savedVisibility && Object.keys(columnVisibility).length === 0) {
       try {
         const parsed = JSON.parse(savedVisibility)
         // Проверяем, есть ли новые столбцы, которых нет в сохраненных настройках
         const updatedVisibility = { ...parsed }
-        allColumnsForSettings.forEach(col => {
+        allColumnsForSettings.forEach((col) => {
           if (!(col.key in updatedVisibility)) {
             updatedVisibility[col.key] = true // Новые столбцы видимы по умолчанию
           }
@@ -942,48 +978,48 @@ export default function Documentation() {
         console.error('Error loading column visibility:', error)
         // Если ошибка парсинга, устанавливаем значения по умолчанию
         const defaultVisibility: Record<string, boolean> = {}
-        allColumnsForSettings.forEach(col => {
+        allColumnsForSettings.forEach((col) => {
           defaultVisibility[col.key] = true
         })
         setColumnVisibility(defaultVisibility)
       }
     } else if (Object.keys(columnVisibility).length === 0) {
       const initialVisibility: Record<string, boolean> = {}
-      allColumnsForSettings.forEach(col => {
+      allColumnsForSettings.forEach((col) => {
         initialVisibility[col.key] = true
       })
       setColumnVisibility(initialVisibility)
     }
-    
+
     if (savedOrder && columnOrder.length === 0) {
       try {
         const parsed = JSON.parse(savedOrder)
         // Добавляем новые столбцы, которых нет в сохраненном порядке
         const existingKeys = new Set(parsed)
-        const newColumns = allColumnsForSettings.filter(col => !existingKeys.has(col.key))
-        const updatedOrder = [...parsed, ...newColumns.map(col => col.key)]
-        
+        const newColumns = allColumnsForSettings.filter((col) => !existingKeys.has(col.key))
+        const updatedOrder = [...parsed, ...newColumns.map((col) => col.key)]
+
         // Убираем столбцы, которые больше не существуют
-        const validKeys = new Set(allColumnsForSettings.map(col => col.key))
-        const filteredOrder = updatedOrder.filter(key => validKeys.has(key))
-        
+        const validKeys = new Set(allColumnsForSettings.map((col) => col.key))
+        const filteredOrder = updatedOrder.filter((key) => validKeys.has(key))
+
         setColumnOrder(filteredOrder)
       } catch (error) {
         console.error('Error loading column order:', error)
-        setColumnOrder(allColumnsForSettings.map(c => c.key))
+        setColumnOrder(allColumnsForSettings.map((c) => c.key))
       }
     } else if (columnOrder.length === 0) {
-      setColumnOrder(allColumnsForSettings.map(c => c.key))
+      setColumnOrder(allColumnsForSettings.map((c) => c.key))
     }
   }, [allColumnsForSettings, columnVisibility, columnOrder])
-  
+
   // Сохранение в localStorage при изменении
   useEffect(() => {
     if (Object.keys(columnVisibility).length > 0) {
       localStorage.setItem('documentation-column-visibility', JSON.stringify(columnVisibility))
     }
   }, [columnVisibility])
-  
+
   useEffect(() => {
     if (columnOrder.length > 0) {
       localStorage.setItem('documentation-column-order', JSON.stringify(columnOrder))
@@ -994,7 +1030,7 @@ export default function Documentation() {
   const handleImportExcel = async () => {
     try {
       const values = await importForm.validateFields()
-      
+
       if (fileList.length === 0) {
         message.error('Выберите файл для импорта')
         return
@@ -1004,22 +1040,22 @@ export default function Documentation() {
       const file = fileList[0].originFileObj
 
       const arrayBuffer = await file!.arrayBuffer()
-      const workbook = XLSX.read(arrayBuffer, { 
+      const workbook = XLSX.read(arrayBuffer, {
         type: 'array',
         cellDates: false, // Не преобразовывать даты автоматически, чтобы получить числовые значения
-        dateNF: 'dd.mm.yyyy' // Формат даты по умолчанию
+        dateNF: 'dd.mm.yyyy', // Формат даты по умолчанию
       })
       const sheetName = workbook.SheetNames[0]
       const worksheet = workbook.Sheets[sheetName]
       const jsonData = XLSX.utils.sheet_to_json(worksheet, {
         raw: true, // Получать сырые значения (числа для дат)
-        defval: undefined // Значение по умолчанию для пустых ячеек
+        defval: undefined, // Значение по умолчанию для пустых ячеек
       })
 
       // Функция для преобразования Excel serial date в формат YYYY-MM-DD
       const excelDateToISO = (excelDate: string | number | undefined): string | undefined => {
         if (!excelDate) return undefined
-        
+
         // Если это уже строка в формате даты (DD.MM.YYYY), преобразуем её
         if (typeof excelDate === 'string' && excelDate.includes('.')) {
           const [day, month, year] = excelDate.split('.')
@@ -1027,52 +1063,55 @@ export default function Documentation() {
             return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
           }
         }
-        
+
         // Если это число (Excel serial date)
         const serialDate = typeof excelDate === 'string' ? parseFloat(excelDate) : excelDate
         if (!isNaN(serialDate)) {
           // Excel's date system: January 1, 1900 is serial date 1
           // Excel incorrectly treats 1900 as a leap year, so we need to adjust
           let adjustedDate = serialDate
-          
+
           // Adjust for Excel's leap year bug (for dates after Feb 28, 1900)
           // Excel serial date 60 = Feb 29, 1900 (which doesn't exist)
           // So for serial dates > 60, we subtract 1
           if (serialDate > 60) {
             adjustedDate = serialDate - 1
           }
-          
+
           // Create date from Excel serial number
           // Excel date 1 = Jan 1, 1900, but JS Date needs milliseconds since Jan 1, 1970
           // Days between Jan 1, 1900 and Jan 1, 1970 = 25567
           const jsDate = new Date((adjustedDate - 25567) * 86400 * 1000)
-          
+
           // Adjust for timezone offset to get the correct date
           const utcDate = new Date(jsDate.getTime() + jsDate.getTimezoneOffset() * 60000)
-          
+
           const year = utcDate.getFullYear()
           const month = String(utcDate.getMonth() + 1).padStart(2, '0')
           const day = String(utcDate.getDate()).padStart(2, '0')
-          
+
           return `${year}-${month}-${day}`
         }
-        
+
         return undefined
       }
 
       // Преобразуем данные в нужный формат с учетом выбранного проекта и стадии
-      const importData: DocumentationImportRow[] = (jsonData as Record<string, string | number | undefined>[]).map((row, index) => {
+      const importData: DocumentationImportRow[] = (
+        jsonData as Record<string, string | number | undefined>[]
+      ).map((row, index) => {
         const processedRow = {
           tag: (row['Раздел'] || '').toString().trim(),
           code: (row['Шифр проекта'] || row['Шифр'] || '').toString().trim(),
           version_number: parseInt((row['Номер версии'] || row['Версия'] || '1').toString()),
           issue_date: excelDateToISO(row['Дата выдачи версии'] || row['Дата выдачи']),
-          file_url: (row['Ссылка'] || row['Ссылка на документ'] || '').toString().trim() || undefined,
+          file_url:
+            (row['Ссылка'] || row['Ссылка на документ'] || '').toString().trim() || undefined,
           project_id: values.project_id,
           block_id: values.block_id, // Добавляем block_id если выбран
           stage: values.stage,
         }
-        
+
         // Логируем первые несколько строк для отладки
         if (index < 3) {
           console.log(`Row ${index + 1}:`, {
@@ -1081,15 +1120,15 @@ export default function Documentation() {
             converted_date: processedRow.issue_date,
             raw_url_value: row['Ссылка'] || row['Ссылка на документ'],
             file_url: processedRow.file_url,
-            all_fields: Object.keys(row)
+            all_fields: Object.keys(row),
           })
         }
-        
+
         return processedRow
       })
 
       // Проверяем на дубликаты внутри файла импорта
-      const duplicatesMap = new Map<string, { rows: DocumentationImportRow[], indices: number[] }>()
+      const duplicatesMap = new Map<string, { rows: DocumentationImportRow[]; indices: number[] }>()
       importData.forEach((row, index) => {
         const key = `${row.code}_${row.version_number}`
         if (!duplicatesMap.has(key)) {
@@ -1106,7 +1145,7 @@ export default function Documentation() {
         .map(([key, entry]) => ({
           key,
           rows: entry.rows,
-          indices: entry.indices
+          indices: entry.indices,
         }))
 
       if (fileDuplicates.length > 0) {
@@ -1121,7 +1160,7 @@ export default function Documentation() {
 
       // Проверяем на конфликты
       const conflicts = await documentationApi.checkForConflicts(importData)
-      
+
       if (conflicts.length > 0) {
         // Есть конфликты - показываем диалог
         setImportConflicts(conflicts)
@@ -1134,7 +1173,9 @@ export default function Documentation() {
         const result = await documentationApi.importFromExcel(importData)
 
         if (result.errors.length > 0) {
-          message.warning(`Импортировано ${result.results.length} записей, ошибок: ${result.errors.length}`)
+          message.warning(
+            `Импортировано ${result.results.length} записей, ошибок: ${result.errors.length}`,
+          )
         } else {
           message.success(`Успешно импортировано ${result.results.length} записей`)
         }
@@ -1158,10 +1199,10 @@ export default function Documentation() {
   const handleConflictResolution = async (resolutions: Map<number, ConflictResolution>) => {
     try {
       setResolvingConflicts(true)
-      
+
       const result = await documentationApi.importFromExcelWithResolutions(
         pendingImportData,
-        resolutions
+        resolutions,
       )
 
       let message_text = `Импортировано: ${result.results.length} записей`
@@ -1176,7 +1217,7 @@ export default function Documentation() {
 
       // Обновляем данные
       queryClient.invalidateQueries({ queryKey: ['documentation'] })
-      
+
       // Очищаем состояние
       setConflictDialogVisible(false)
       setImportConflicts([])
@@ -1214,15 +1255,15 @@ export default function Documentation() {
 
       // Фильтруем importData, оставляя только выбранные строки
       const indicesToKeep = new Set<number>()
-      
+
       // Добавляем индексы выбранных строк из дубликатов
       selectedDuplicates.forEach((selectedIndex) => {
         indicesToKeep.add(selectedIndex)
       })
-      
+
       // Добавляем индексы строк, которые не являются дубликатами
       pendingImportData.forEach((_, index) => {
-        const isDuplicate = fileDuplicates.some(dup => dup.indices.includes(index))
+        const isDuplicate = fileDuplicates.some((dup) => dup.indices.includes(index))
         if (!isDuplicate) {
           indicesToKeep.add(index)
         }
@@ -1238,7 +1279,7 @@ export default function Documentation() {
 
       // Проверяем на конфликты с базой данных
       const conflicts = await documentationApi.checkForConflicts(filteredData)
-      
+
       if (conflicts.length > 0) {
         // Есть конфликты - показываем диалог
         setImportConflicts(conflicts)
@@ -1249,7 +1290,9 @@ export default function Documentation() {
         const result = await documentationApi.importFromExcel(filteredData)
 
         if (result.errors.length > 0) {
-          message.warning(`Импортировано ${result.results.length} записей, ошибок: ${result.errors.length}`)
+          message.warning(
+            `Импортировано ${result.results.length} записей, ошибок: ${result.errors.length}`,
+          )
         } else {
           message.success(`Успешно импортировано ${result.results.length} записей`)
         }
@@ -1314,15 +1357,14 @@ export default function Documentation() {
     setAddMode(true)
   }
 
-
   // Сохранение всех новых записей
   const handleSaveAll = async () => {
     try {
       console.log('Saving rows with appliedFilters:', appliedFilters)
       for (const row of newRows) {
-        const tagId = tags.find(t => t.name === row.tag_name)?.id
+        const tagId = tags.find((t) => t.name === row.tag_name)?.id
         console.log('Saving row with project_id:', row.project_id, 'block_id:', row.block_id)
-        
+
         // Используем комплексный метод сохранения
         await documentationApi.saveDocumentationComplete({
           code: row.project_code,
@@ -1354,20 +1396,21 @@ export default function Documentation() {
     setAddMode(false)
   }
 
-
   // Объединение данных для таблицы
   const tableData = useMemo(() => {
     return [...newRows, ...documentation]
   }, [newRows, documentation])
 
   return (
-    <div style={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
 
-      minHeight: 0
-    }}>
+        minHeight: 0,
+      }}
+    >
       <div className="filters" style={{ flexShrink: 0, paddingBottom: 16 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
           <Space align="center" size="middle">
@@ -1377,18 +1420,23 @@ export default function Documentation() {
               style={{ width: 280 * scale }}
               size="large"
               value={filters.project_id}
-              onChange={(value) => setFilters({ ...filters, project_id: value, block_id: undefined })}
-              options={projects?.map((p) => ({
-                value: p.id, 
-                label: <span style={{ fontWeight: 'bold' }}>{p.name}</span> 
-              })) ?? []}
+              onChange={(value) =>
+                setFilters({ ...filters, project_id: value, block_id: undefined })
+              }
+              options={
+                projects?.map((p) => ({
+                  value: p.id,
+                  label: <span style={{ fontWeight: 'bold' }}>{p.name}</span>,
+                })) ?? []
+              }
               allowClear
               showSearch
               filterOption={(input, option) => {
                 const label = option?.label
                 if (!label) return false
                 if (typeof label === 'object' && 'props' in label) {
-                  const text = ((label as React.ReactElement).props as { children?: string })?.children || ''
+                  const text =
+                    ((label as React.ReactElement).props as { children?: string })?.children || ''
                   if (typeof text === 'string') {
                     return text.toLowerCase().includes(input.toLowerCase())
                   }
@@ -1421,7 +1469,8 @@ export default function Documentation() {
                 const label = option?.label
                 if (!label) return false
                 if (typeof label === 'object' && 'props' in label) {
-                  const text = ((label as React.ReactElement).props as { children?: string })?.children || ''
+                  const text =
+                    ((label as React.ReactElement).props as { children?: string })?.children || ''
                   if (typeof text === 'string') {
                     return text.toLowerCase().includes(input.toLowerCase())
                   }
@@ -1434,16 +1483,18 @@ export default function Documentation() {
               onChange={(value) => setFilters({ ...filters, tag_id: value })}
               options={tags.map((t) => ({ label: t.name, value: t.id }))}
             />
-            <Button 
-              type="primary" 
+            <Button
+              type="primary"
               size="large"
-              onClick={handleApply} 
+              onClick={handleApply}
               disabled={!filters.project_id}
             >
               Применить
             </Button>
-            <Badge 
-              count={[filters.block_id, filters.status, filters.show_latest_only].filter(Boolean).length} 
+            <Badge
+              count={
+                [filters.block_id, filters.status, filters.show_latest_only].filter(Boolean).length
+              }
               size="small"
               style={{ marginRight: '8px' }}
             >
@@ -1452,11 +1503,14 @@ export default function Documentation() {
                 onClick={() => setFiltersExpanded(!filtersExpanded)}
                 icon={
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                      <FilterOutlined style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }} />
-                      {filtersExpanded ?
-                        <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} /> :
-                        <CaretDownFilled style={{ fontSize: '10px' }} />
-                    }
+                    <FilterOutlined
+                      style={{ fontSize: '16px', color: filtersExpanded ? '#a69ead' : undefined }}
+                    />
+                    {filtersExpanded ? (
+                      <CaretUpFilled style={{ fontSize: '10px', color: '#a69ead' }} />
+                    ) : (
+                      <CaretDownFilled style={{ fontSize: '10px' }} />
+                    )}
                   </span>
                 }
               >
@@ -1465,36 +1519,27 @@ export default function Documentation() {
             </Badge>
           </Space>
           <Space>
-            {appliedFilters.project_id && !addMode && !Object.keys(editingRows).length && !deleteMode && (
-              <Button
-                type="primary"
-                icon={<PlusOutlined />}
-                onClick={handleAddRow}
-              >
-                Добавить
-              </Button>
-            )}
+            {appliedFilters.project_id &&
+              !addMode &&
+              !Object.keys(editingRows).length &&
+              !deleteMode && (
+                <Button type="primary" icon={<PlusOutlined />} onClick={handleAddRow}>
+                  Добавить
+                </Button>
+              )}
             {addMode && (
               <>
-                <Button
-                  type="primary"
-                  icon={<SaveOutlined />}
-                  onClick={handleSaveAll}
-                  size="large"
-                >
+                <Button type="primary" icon={<SaveOutlined />} onClick={handleSaveAll} size="large">
                   Сохранить
                 </Button>
-                <Button
-                  onClick={handleCancelAll}
-                  size="large"
-                >
+                <Button onClick={handleCancelAll} size="large">
                   Отмена
                 </Button>
               </>
             )}
             {Object.keys(editingRows).length > 0 && (
               <>
-                <Button 
+                <Button
                   type="primary"
                   icon={<SaveOutlined />}
                   onClick={async () => {
@@ -1539,7 +1584,7 @@ export default function Documentation() {
                         setSelectedRowsForDelete(new Set())
                         setDeleteMode(false)
                         queryClient.invalidateQueries({ queryKey: ['documentation'] })
-                      }
+                      },
                     })
                   } else {
                     setDeleteMode(!deleteMode)
@@ -1548,11 +1593,11 @@ export default function Documentation() {
                 }}
                 disabled={addMode}
               >
-                {deleteMode && selectedRowsForDelete.size > 0 
+                {deleteMode && selectedRowsForDelete.size > 0
                   ? `Удалить (${selectedRowsForDelete.size})`
-                  : deleteMode 
-                  ? 'Выйти из режима' 
-                  : 'Удалить'}
+                  : deleteMode
+                    ? 'Выйти из режима'
+                    : 'Удалить'}
               </Button>
             )}
             {deleteMode && selectedRowsForDelete.size === 0 && appliedFilters.project_id && (
@@ -1577,31 +1622,43 @@ export default function Documentation() {
 
         {/* Развернутые фильтры */}
         {filtersExpanded && (
-          <div style={{ 
-            marginBottom: 16, 
-            padding: '16px',
-            backgroundColor: '#f5f5f5',
-            borderRadius: '8px'
-          }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
+          <div
+            style={{
+              marginBottom: 16,
+              padding: '16px',
+              backgroundColor: '#f5f5f5',
+              borderRadius: '8px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: '8px',
+              }}
+            >
               <Space wrap>
                 <Select
                   style={{ width: 200 }}
                   placeholder="Корпус"
                   allowClear
                   showSearch
-              filterOption={(input, option) => {
-                const label = option?.label
-                if (!label) return false
-                if (typeof label === 'object' && 'props' in label) {
-                  const text = ((label as React.ReactElement).props as { children?: string })?.children || ''
-                  if (typeof text === 'string') {
-                    return text.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
-                }
-                return String(label).toLowerCase().includes(input.toLowerCase())
-              }}
+                  filterOption={(input, option) => {
+                    const label = option?.label
+                    if (!label) return false
+                    if (typeof label === 'object' && 'props' in label) {
+                      const text =
+                        ((label as React.ReactElement).props as { children?: string })?.children ||
+                        ''
+                      if (typeof text === 'string') {
+                        return text.toLowerCase().includes(input.toLowerCase())
+                      }
+                      return false
+                    }
+                    return String(label).toLowerCase().includes(input.toLowerCase())
+                  }}
                   disabled={!filters.project_id}
                   value={filters.block_id}
                   onChange={(value) => setFilters({ ...filters, block_id: value })}
@@ -1612,18 +1669,20 @@ export default function Documentation() {
                   placeholder="Статус"
                   allowClear
                   showSearch
-              filterOption={(input, option) => {
-                const label = option?.label
-                if (!label) return false
-                if (typeof label === 'object' && 'props' in label) {
-                  const text = ((label as React.ReactElement).props as { children?: string })?.children || ''
-                  if (typeof text === 'string') {
-                    return text.toLowerCase().includes(input.toLowerCase())
-                  }
-                  return false
-                }
-                return String(label).toLowerCase().includes(input.toLowerCase())
-              }}
+                  filterOption={(input, option) => {
+                    const label = option?.label
+                    if (!label) return false
+                    if (typeof label === 'object' && 'props' in label) {
+                      const text =
+                        ((label as React.ReactElement).props as { children?: string })?.children ||
+                        ''
+                      if (typeof text === 'string') {
+                        return text.toLowerCase().includes(input.toLowerCase())
+                      }
+                      return false
+                    }
+                    return String(label).toLowerCase().includes(input.toLowerCase())
+                  }}
                   value={filters.status}
                   onChange={(value) => setFilters({ ...filters, status: value })}
                   options={[
@@ -1634,10 +1693,7 @@ export default function Documentation() {
                   ]}
                 />
               </Space>
-              <Button
-                icon={<SettingOutlined />}
-                onClick={() => setSettingsDrawerOpen(true)}
-              >
+              <Button icon={<SettingOutlined />} onClick={() => setSettingsDrawerOpen(true)}>
                 Настройка столбцов
               </Button>
             </div>
@@ -1647,7 +1703,6 @@ export default function Documentation() {
 
       {/* Таблица */}
       <div className="table-host">
-
         {!appliedFilters.project_id ? (
           <Empty
             description="Выберите проект для просмотра документации"
@@ -1671,17 +1726,16 @@ export default function Documentation() {
             }}
             sticky
             scroll={{
-              x: 'max-content'
-
+              x: 'max-content',
             }}
-          // TODO: раскомментировать после добавления колонки color в БД
-          /*onRow={(record: DocumentationTableRow) => ({
+            // TODO: раскомментировать после добавления колонки color в БД
+            /*onRow={(record: DocumentationTableRow) => ({
             style: {
               backgroundColor: record.color ? colorMap[record.color as RowColor] : undefined,
             },
           })}*/
-        />
-      )}
+          />
+        )}
       </div>
 
       {/* Drawer настроек столбцов */}
@@ -1692,55 +1746,63 @@ export default function Documentation() {
         open={settingsDrawerOpen}
         width={350}
       >
-        <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div
+          style={{
+            marginBottom: 16,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
           <Checkbox
-            checked={allColumnsForSettings.every(col => columnVisibility[col.key] !== false)}
-            indeterminate={allColumnsForSettings.some(col => columnVisibility[col.key]) && !allColumnsForSettings.every(col => columnVisibility[col.key] !== false)}
+            checked={allColumnsForSettings.every((col) => columnVisibility[col.key] !== false)}
+            indeterminate={
+              allColumnsForSettings.some((col) => columnVisibility[col.key]) &&
+              !allColumnsForSettings.every((col) => columnVisibility[col.key] !== false)
+            }
             onChange={(e) => selectAllColumns(e.target.checked, allColumnsForSettings)}
           >
             Выделить все
           </Checkbox>
-          <Button
-            type="link"
-            onClick={() => resetToDefaults(allColumnsForSettings)}
-          >
+          <Button type="link" onClick={() => resetToDefaults(allColumnsForSettings)}>
             По умолчанию
           </Button>
         </div>
         <List
-          dataSource={columnOrder.map(key => {
-            const col = allColumnsForSettings.find(c => c.key === key)
-            return col ? { ...col, visible: columnVisibility[key] !== false } : null
-          }).filter(Boolean)}
-          renderItem={(item, index) => item && (
-            <List.Item
-              actions={[
-                <Button
-                  key="up"
-                  type="text"
-                  icon={<ArrowUpOutlined />}
-                  onClick={() => moveColumn(item.key, 'up')}
-                  disabled={index === 0}
-                  size="small"
-                />,
-                <Button
-                  key="down"
-                  type="text"
-                  icon={<ArrowDownOutlined />}
-                  onClick={() => moveColumn(item.key, 'down')}
-                  disabled={index === columnOrder.length - 1}
-                  size="small"
-                />
-              ]}
-            >
-              <Checkbox
-                checked={item.visible}
-                onChange={() => toggleColumnVisibility(item.key)}
+          dataSource={columnOrder
+            .map((key) => {
+              const col = allColumnsForSettings.find((c) => c.key === key)
+              return col ? { ...col, visible: columnVisibility[key] !== false } : null
+            })
+            .filter(Boolean)}
+          renderItem={(item, index) =>
+            item && (
+              <List.Item
+                actions={[
+                  <Button
+                    key="up"
+                    type="text"
+                    icon={<ArrowUpOutlined />}
+                    onClick={() => moveColumn(item.key, 'up')}
+                    disabled={index === 0}
+                    size="small"
+                  />,
+                  <Button
+                    key="down"
+                    type="text"
+                    icon={<ArrowDownOutlined />}
+                    onClick={() => moveColumn(item.key, 'down')}
+                    disabled={index === columnOrder.length - 1}
+                    size="small"
+                  />,
+                ]}
               >
-                {item.title}
-              </Checkbox>
-            </List.Item>
-          )}
+                <Checkbox checked={item.visible} onChange={() => toggleColumnVisibility(item.key)}>
+                  {item.title}
+                </Checkbox>
+              </List.Item>
+            )
+          }
         />
       </Drawer>
 
@@ -1774,10 +1836,12 @@ export default function Documentation() {
           >
             <Select
               placeholder="Выберите проект"
-              options={projects?.map((p) => ({ 
-                value: p.id, 
-                label: p.name,
-              })) ?? []}
+              options={
+                projects?.map((p) => ({
+                  value: p.id,
+                  label: p.name,
+                })) ?? []
+              }
               showSearch
               filterOption={(input, option) => {
                 const label = option?.label
@@ -1794,17 +1858,15 @@ export default function Documentation() {
             />
           </Form.Item>
 
-          <Form.Item
-            name="block_id"
-            label="Корпус"
-            rules={[{ required: false }]}
-          >
+          <Form.Item name="block_id" label="Корпус" rules={[{ required: false }]}>
             <Select
               placeholder="Выберите корпус (необязательно)"
-              options={importBlocks?.map((b) => ({ 
-                value: b.id, 
-                label: b.name,
-              })) ?? []}
+              options={
+                importBlocks?.map((b) => ({
+                  value: b.id,
+                  label: b.name,
+                })) ?? []
+              }
               allowClear
               disabled={!importSelectedProjectId}
               showSearch
@@ -1846,7 +1908,8 @@ export default function Documentation() {
               <p className="ant-upload-hint">
                 Поддерживаются файлы Excel (.xlsx, .xls)
                 <br />
-                Файл должен содержать столбцы: Раздел, Шифр проекта, Номер версии, Дата выдачи версии, Ссылка
+                Файл должен содержать столбцы: Раздел, Шифр проекта, Номер версии, Дата выдачи
+                версии, Ссылка
               </p>
             </Upload.Dragger>
           </Form.Item>
@@ -1874,15 +1937,25 @@ export default function Documentation() {
       >
         <div style={{ marginBottom: 16 }}>
           <Text>
-            В файле обнаружены строки с одинаковым сочетанием шифра документа и версии.
-            Выберите, какую строку импортировать для каждого дубликата:
+            В файле обнаружены строки с одинаковым сочетанием шифра документа и версии. Выберите,
+            какую строку импортировать для каждого дубликата:
           </Text>
         </div>
         {fileDuplicates.map((duplicate) => {
           const [code, version] = duplicate.key.split('_')
           return (
-            <div key={duplicate.key} style={{ marginBottom: 24, border: '1px solid #d9d9d9', padding: 16, borderRadius: 4 }}>
-              <Title level={5}>Шифр: {code}, Версия: {version}</Title>
+            <div
+              key={duplicate.key}
+              style={{
+                marginBottom: 24,
+                border: '1px solid #d9d9d9',
+                padding: 16,
+                borderRadius: 4,
+              }}
+            >
+              <Title level={5}>
+                Шифр: {code}, Версия: {version}
+              </Title>
               <Radio.Group
                 value={selectedDuplicates.get(duplicate.key)}
                 onChange={(e) => {
@@ -1896,7 +1969,7 @@ export default function Documentation() {
                   dataSource={duplicate.rows.map((row, idx) => ({
                     key: duplicate.indices[idx],
                     rowIndex: duplicate.indices[idx],
-                    ...row
+                    ...row,
                   }))}
                   columns={[
                     {
@@ -1905,44 +1978,42 @@ export default function Documentation() {
                       key: 'select',
                       width: 80,
                       align: 'center',
-                      render: (rowIndex: number) => (
-                        <Radio value={rowIndex} />
-                      )
+                      render: (rowIndex: number) => <Radio value={rowIndex} />,
                     },
                     {
                       title: '№ строки',
                       dataIndex: 'rowIndex',
                       key: 'rowIndex',
                       width: 90,
-                      render: (index: number) => `${index + 1}`
+                      render: (index: number) => `${index + 1}`,
                     },
                     {
                       title: 'Раздел',
                       dataIndex: 'tag',
                       key: 'tag',
                       width: 200,
-                      render: (text: string) => text || '-'
+                      render: (text: string) => text || '-',
                     },
                     {
                       title: 'Шифр проекта',
                       dataIndex: 'code',
                       key: 'code',
                       width: 150,
-                      render: (text: string) => text || '-'
+                      render: (text: string) => text || '-',
                     },
                     {
                       title: 'Версия',
                       dataIndex: 'version_number',
                       key: 'version_number',
                       width: 80,
-                      align: 'center'
+                      align: 'center',
                     },
                     {
                       title: 'Дата выдачи',
                       dataIndex: 'issue_date',
                       key: 'issue_date',
                       width: 120,
-                      render: (date: string) => date ? formatDate(date) : '-'
+                      render: (date: string) => (date ? formatDate(date) : '-'),
                     },
                     {
                       title: 'Ссылка на документ',
@@ -1950,13 +2021,16 @@ export default function Documentation() {
                       key: 'file_url',
                       width: 150,
                       ellipsis: true,
-                      render: (url: string) => url ? (
-                        <Tooltip title={url}>
-                          <a href={url} target="_blank" rel="noopener noreferrer">
-                            Открыть
-                          </a>
-                        </Tooltip>
-                      ) : '-'
+                      render: (url: string) =>
+                        url ? (
+                          <Tooltip title={url}>
+                            <a href={url} target="_blank" rel="noopener noreferrer">
+                              Открыть
+                            </a>
+                          </Tooltip>
+                        ) : (
+                          '-'
+                        ),
                     },
                     {
                       title: 'Стадия',
@@ -1964,8 +2038,8 @@ export default function Documentation() {
                       key: 'stage',
                       width: 80,
                       align: 'center',
-                      render: (stage: string) => stage || 'П'
-                    }
+                      render: (stage: string) => stage || 'П',
+                    },
                   ]}
                   pagination={false}
                   size="small"


### PR DESCRIPTION
## Summary
- include version file paths when loading documentation
- align types and local file updates with database schema
- move working Documentation page from References to Documents section

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b44a73bb0c832eafeac830569e4960