### PR TITLE
fix: remove disk mappings filling

### DIFF
--- a/src/entities/disk/api/disk-api.ts
+++ b/src/entities/disk/api/disk-api.ts
@@ -5,10 +5,7 @@ export const diskApi = {
   async getSettings(): Promise<DiskSettings | null> {
     if (!supabase) throw new Error('Supabase client not initialized')
 
-    const { data, error } = await supabase
-      .from('disk_settings')
-      .select('*')
-      .single()
+    const { data, error } = await supabase.from('disk_settings').select('*').single()
 
     if (error && error.code !== 'PGRST116') {
       console.error('Failed to fetch disk settings:', error)
@@ -21,10 +18,7 @@ export const diskApi = {
   async upsertSettings(input: Partial<DiskSettings>): Promise<DiskSettings> {
     if (!supabase) throw new Error('Supabase client not initialized')
 
-    const { data: existing } = await supabase
-      .from('disk_settings')
-      .select('id')
-      .single()
+    const { data: existing } = await supabase.from('disk_settings').select('id').single()
 
     const query = supabase.from('disk_settings')
     const { data, error } = existing
@@ -38,15 +32,4 @@ export const diskApi = {
 
     return data as DiskSettings
   },
-
-  async fillMappings(): Promise<void> {
-    if (!supabase) throw new Error('Supabase client not initialized')
-
-    const { error } = await supabase.rpc('fill_storage_mappings', {})
-
-    if (error) {
-      console.error('Failed to fill storage mappings:', error)
-      throw error
-    }
-  }
 }

--- a/src/pages/admin/Disk.tsx
+++ b/src/pages/admin/Disk.tsx
@@ -10,7 +10,7 @@ export default function Disk() {
 
   const { data, isLoading } = useQuery({
     queryKey: ['disk-settings'],
-    queryFn: diskApi.getSettings
+    queryFn: diskApi.getSettings,
   })
 
   useEffect(() => {
@@ -27,26 +27,11 @@ export default function Disk() {
     onError: (err) => {
       console.error('Failed to save settings:', err)
       message.error('Не удалось сохранить настройки')
-    }
+    },
   })
 
   const handleFinish = async (values: DiskSettings) => {
     await mutation.mutateAsync(values)
-  }
-
-  const fillMutation = useMutation({
-    mutationFn: diskApi.fillMappings,
-    onSuccess: () => {
-      message.success('Таблица заполнена')
-    },
-    onError: (err) => {
-      console.error('Failed to fill mappings:', err)
-      message.error('Не удалось заполнить таблицу')
-    }
-  })
-
-  const handleFill = async () => {
-    await fillMutation.mutateAsync()
   }
 
   return (
@@ -57,12 +42,7 @@ export default function Disk() {
             Диск
           </Title>
         </div>
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={handleFinish}
-          autoComplete="off"
-        >
+        <Form form={form} layout="vertical" onFinish={handleFinish} autoComplete="off">
           <Form.Item
             label="OAuth токен"
             name="token"
@@ -75,19 +55,14 @@ export default function Disk() {
             name="base_path"
             rules={[{ required: true, message: 'Введите путь' }]}
           >
-
             <Input placeholder="Например, disk:/blueprintflow" />
-
           </Form.Item>
           <Form.Item label="Публиковать автоматически" name="make_public" valuePropName="checked">
             <Switch />
           </Form.Item>
           <Form.Item style={{ textAlign: 'right' }}>
-            <Button type="primary" htmlType="submit" loading={mutation.isPending} style={{ marginRight: 8 }}>
+            <Button type="primary" htmlType="submit" loading={mutation.isPending}>
               Сохранить
-            </Button>
-            <Button onClick={handleFill} loading={fillMutation.isPending}>
-              Заполнить соответствия
             </Button>
           </Form.Item>
         </Form>


### PR DESCRIPTION
## Summary
- remove "Заполнить соответствия" button and related logic on Disk admin page
- drop `fill_storage_mappings` RPC integration

## Testing
- `npm run lint`
- `npm run format` *(global formatting)*
- `npm run format:check` *(failed: code style issues in unrelated files)*
- `npx prettier src/pages/admin/Disk.tsx src/entities/disk/api/disk-api.ts --check`
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b455417e68832ea62f2faac0c00c3b